### PR TITLE
Fix crash on disconnect

### DIFF
--- a/client/src/Containers/Workspace/GgbGraph.js
+++ b/client/src/Containers/Workspace/GgbGraph.js
@@ -70,7 +70,6 @@ class GgbGraph extends Component {
     let isInControl = this.props.room.controlledBy === this.props.user._id;
     let isSomeoneElseInControl = this.props.room.controlledBy && !isInControl;
     if (!wasInControl && isInControl) {
-      console.log('im in control now')
       this.setState({switchingControl: true}, () => {
         if (this.ggbApplet) {
           this.ggbApplet.setMode(0)
@@ -276,8 +275,7 @@ class GgbGraph extends Component {
 
   sendEvent = throttle(async (xml, definition, label, eventType, action) => {
     if (!this.props.user.connected) {
-      console.log("WE NEED TO UNDO THE LAST EVENT")
-      this.ggbApplet.undo()
+      this.ggbApplet.undo() // We should never reach this block because control should be prevented if user is not connected
       return;
     }
     let xmlObj;

--- a/client/src/Containers/Workspace/GgbGraph.js
+++ b/client/src/Containers/Workspace/GgbGraph.js
@@ -65,16 +65,20 @@ class GgbGraph extends Component {
   }
 
   async componentDidUpdate(prevProps) {
+    if (!this.ggbApplet) return;
     let wasInControl = prevProps.room.controlledBy === this.props.user._id;
     let isInControl = this.props.room.controlledBy === this.props.user._id;
     let isSomeoneElseInControl = this.props.room.controlledBy && !isInControl;
     if (!wasInControl && isInControl) {
+      console.log('im in control now')
       this.setState({switchingControl: true}, () => {
-        this.ggbApplet.setMode(0)
-        // im not really sure what this does we seem to get the same menu whether we specify all these numbers or not...but it was breaking the hamburger menu to do so
-        // this.ggbApplet.showToolBar("0 39 73 62 | 1 501 67 , 5 19 , 72 75 76 | 2 15 45 , 18 65 , 7 37 | 4 3 8 9 , 13 44 , 58 , 47 | 16 51 64 , 70 | 10 34 53 11 , 24  20 22 , 21 23 | 55 56 57 , 12 | 36 46 , 38 49  50 , 71  14  68 | 30 29 54 32 31 33 | 25 17 26 60 52 61 | 40 41 42 , 27 28 35 , 6")
-        this.ggbApplet.showMenuBar(true)
-        this.freezeElements(false)
+        if (this.ggbApplet) {
+          this.ggbApplet.setMode(0)
+          // im not really sure what this does we seem to get the same menu whether we specify all these numbers or not...but it was breaking the hamburger menu to do so
+          // this.ggbApplet.showToolBar("0 39 73 62 | 1 501 67 , 5 19 , 72 75 76 | 2 15 45 , 18 65 , 7 37 | 4 3 8 9 , 13 44 , 58 , 47 | 16 51 64 , 70 | 10 34 53 11 , 24  20 22 , 21 23 | 55 56 57 , 12 | 36 46 , 38 49  50 , 71  14  68 | 30 29 54 32 31 33 | 25 17 26 60 52 61 | 40 41 42 , 27 28 35 , 6")
+          this.ggbApplet.showMenuBar(true)
+          this.freezeElements(false)
+        }
         // setTimeout(() => {
           this.setState({switchingControl: false})
         // }, 0)
@@ -83,6 +87,7 @@ class GgbGraph extends Component {
     }
     else if ((wasInControl && !isInControl )|| isSomeoneElseInControl) {
       this.ggbApplet.showToolBar(false)
+      this.ggbApplet.showMenuBar(false)
       this.ggbApplet.setMode(40)
       this.freezeElements(true)
     }
@@ -201,7 +206,6 @@ class GgbGraph extends Component {
     } else if (startingPoint) {
       this.ggbApplet.setXML(startingPoint)
     } else if (ggbFile) {
-      console.log('setting ggbFile')
       this.ggbApplet.setBase64(ggbFile);
     }
     // attach this listeners to the ggbApplet
@@ -215,6 +219,7 @@ class GgbGraph extends Component {
       let definition = this.ggbApplet.getCommandString(label);
       this.sendEvent(xml, definition, label, "ADD", "added");
     }
+    this.ggbApplet.setUndoPoint()
     this.setState({receivingData: false})
   }
 
@@ -222,6 +227,7 @@ class GgbGraph extends Component {
     if (!this.state.receivingData) {
       this.sendEvent(null, null, label, "REMOVE", "removed")
     }
+    this.ggbApplet.setUndoPoint()
     this.setState({receivingData: false})
   }
 
@@ -234,6 +240,7 @@ class GgbGraph extends Component {
       let xml = this.ggbApplet.getXML(label)
       this.sendEvent(xml, null, label, "UPDATE", "updated")
     }
+    this.ggbApplet.setUndoPoint()
     this.setState({receivingData: false})
     // this.ggbApplet.evalCommand("updateConstruction()")
   }
@@ -255,7 +262,7 @@ class GgbGraph extends Component {
   }
 
   registerListeners() {
-    if (this.ggbApplet.listeners.length === 0) {
+    if (this.ggbApplet.listeners.length > 0) {
       this.ggbApplet.unregisterAddListener(this.addListener);
       this.ggbApplet.unregisterUpdateListener(this.updateListener);
       this.ggbApplet.unregisterRemoveListener(this.eventListener);
@@ -268,6 +275,11 @@ class GgbGraph extends Component {
   }
 
   sendEvent = throttle(async (xml, definition, label, eventType, action) => {
+    if (!this.props.user.connected) {
+      console.log("WE NEED TO UNDO THE LAST EVENT")
+      this.ggbApplet.undo()
+      return;
+    }
     let xmlObj;
     if (xml) xmlObj = await this.parseXML(xml)
     let newData = {

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -28,8 +28,6 @@ class Workspace extends Component {
     this.props.updateUser({connected: socket.connected});
     this.initializeListeners();
     this.props.populateRoom(this.props.room._id)
-    setTimeout(() => {socket.disconnect()}, 20000)
-    // setTimeout(() => {socket.connect('/')}, 25000)
     window.addEventListener('beforeunload', this.componentCleanup);
   }
 
@@ -47,7 +45,6 @@ class Workspace extends Component {
     }
 
     if (!this.props.user.connected && this.props.room.controlledBy === this.props.user._id) {
-      console.log('lost connection while in control')
       let auto = true
       this.toggleControl(null, auto); // auto = true
     }

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -28,7 +28,8 @@ class Workspace extends Component {
     this.props.updateUser({connected: socket.connected});
     this.initializeListeners();
     this.props.populateRoom(this.props.room._id)
-
+    setTimeout(() => {socket.disconnect()}, 20000)
+    // setTimeout(() => {socket.connect('/')}, 25000)
     window.addEventListener('beforeunload', this.componentCleanup);
   }
 
@@ -45,10 +46,10 @@ class Workspace extends Component {
       })
     }
 
-    if (!prevProps.user.connected && this.props.user.connected) {
-      // this.initializeListeners();
-    } else if (!this.props.user.connected && this.state.inControl) {
-      this.toggleControl();
+    if (!this.props.user.connected && this.props.room.controlledBy === this.props.user._id) {
+      console.log('lost connection while in control')
+      let auto = true
+      this.toggleControl(null, auto); // auto = true
     }
   }
 
@@ -161,11 +162,11 @@ class Workspace extends Component {
     this.setState({currentTab: index, activityOnOtherTabs: updatedTabs})
   }
 
-  toggleControl = () => {
+  toggleControl = (event, auto) => {
     let { room, user, } = this.props;
 
-    if (!user.connected) {
-      return alert('You have disconnected from the server. Check your internet connection and try refreshing the page')
+    if (!user.connected && !auto) { // i.e. if the user clicked the button manually instead of controll being toggled programatically
+      return alert('You have disconnected from the server. Check your internet connection and try refreshing the page');
     }
 
     if (room.controlledBy === user._id) { // Releasing control
@@ -212,6 +213,9 @@ class Workspace extends Component {
           // this.scrollToBottom(); @TODO
       })
     }
+    if (!user.connected) {
+      setTimeout(() => alert('You have disconnected from the server. Check your internet connection and try refreshing the page'), 0) // Let all of the state updates finish and then show an alert
+    }
   }
 
   resetControlTimer = () => {
@@ -219,7 +223,7 @@ class Workspace extends Component {
     this.controlTimer = setTimeout(() => {
       this.toggleControl()
       // this.props.updatedRoom(this.props.room._id, {controlledBy: null})
-    }, 3 * 1000)
+    }, 60 * 1000)
   }
 
   startNewReference = () => {


### PR DESCRIPTION
* When a user was interacting with a geogebra construction and they lost connection the app would crash because control was not being released at the appropriate time...i.e. after connection was lost but before any manipulation to the construction could be done. This [video](https://drive.google.com/open?id=1JjTaJn_bIqeNHZO5HitaxtMeeM3z9MFH) shows the bug. 

* This bug originated in the `toggleControl` method of containers/workspace the first thing we were doing was checking if the user was connected and if not we returned an alert. This had the effect of skipping the functionality that actually releases control. To fix we've added two place alerts can happen (at the beginning like before if toggling control was triggered manually by the user...In that case we DONT want to update the room's controlled by field. Then we added another check to display an alert at the end which checks the connection but also checks to make sure this method was triggered by the loss of connection and NOT by the user. In this case we DO want to update the room's controlledBy field to null and then display the alert.

* NB because the alert is blocking it is in a setTimout with duration of zero so that it happens after all the UI updates (changing control button and connection status)