### PR TITLE
populate all activity tabs

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -85,7 +85,7 @@ module.exports = passport => {
         // populate: {path: 'currentMembers.user', select: 'username'},
         populate: {path: 'members.user', select: 'username'},
       })
-      .populate('activities')
+      .populate({path: 'activities', populate: {path: 'tabs'}})
       .populate({path: 'notifications', populate: {path: 'fromUser', select: 'username'}})
       // .populate('rooms', 'notifications.user name description isPublic creator roomType')
       // .populate('activities', 'name description isPublic creator roomType rooms')

--- a/controllers/RoomController.js
+++ b/controllers/RoomController.js
@@ -71,6 +71,7 @@ module.exports = {
 
 
       let room = new Room(body)
+      // console.log("ROOM:", room)
       if (existingTabs) {
         tabModels = existingTabs.map(tab => {
           delete tab._id;


### PR DESCRIPTION
previous pr created problems for assigning activity to room. Sometimes tabs were populated other times they were not. this may be worth revisiting at some point because now we're over fetching...but by populating all of the users activities' tabs on login we solve this problem. When a room is created from an activity the tabs are always populated...

...I think what we should ultimately do is just send the tab ids with the post request regardless of their population status. 