### PR TITLE
Desmos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To provide the colloaboration infrastructure, this application uses a combinatio
    cd back up to root...
 1. cp .enx.example .env
 1. `$ npm run start-dev` This will start the react development server on port 3000 and the express server on 3001
+1. We utilize [prettier](https://prettier.io/) for formatting.
 
 ## Deployment
 

--- a/client/src/Containers/Workspace/ActivityWorkspace.js
+++ b/client/src/Containers/Workspace/ActivityWorkspace.js
@@ -178,9 +178,7 @@ class ActivityWorkspace extends Component {
           <Button click={this.createNewActivity}>Copy Activity</Button>
         </Modal>
       </Aux>
-    ) : (
-      <Modal show={this.state.loading} message="Loading..." />
-    );
+    ) : null;
   }
 }
 

--- a/client/src/Containers/Workspace/DesmosActivityGraph.js
+++ b/client/src/Containers/Workspace/DesmosActivityGraph.js
@@ -32,6 +32,8 @@ class DesmosActivityGraph extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    let { activity, currentTab } = this.props;
+    let { tabs } = activity;
     if (prevProps.currentTab !== this.props.currentTab) {
       if (this.props.role === "facilitator") {
         let updatedTabs = [...prevProps.activity.tabs];
@@ -40,6 +42,9 @@ class DesmosActivityGraph extends Component {
           ...this.calculator.getState()
         });
         updatedTabs[this.props.currentTab] = updatedTab;
+        this.props.updateActivityTab(this.props.activity._id, updatedTab._id, {
+          currentState: updatedTab.currentState
+        });
       }
       this.calculator.setState(
         this.props.activity.tabs[this.props.currentTab].currentState
@@ -56,6 +61,9 @@ class DesmosActivityGraph extends Component {
         ...this.calculator.getState()
       });
       updatedTabs[this.props.currentTab] = updatedTab;
+      this.props.updateActivityTab(this.props.activity._id, updatedTab._id, {
+        currentState: updatedTab.currentState
+      });
     }
     this.calculator.unobserveEvent("change");
     this.calculator.destroy();

--- a/client/src/Containers/Workspace/DesmosActivityGraph.js
+++ b/client/src/Containers/Workspace/DesmosActivityGraph.js
@@ -12,9 +12,7 @@ class DesmosActivityGraph extends Component {
   calculatorRef = React.createRef();
 
   componentDidMount() {
-    console.log("MOUNTED");
     if (window.Desmos) {
-      console.log("alreadt have desmos");
       let { activity, currentTab } = this.props;
       let { tabs } = activity;
       this.calculator = window.Desmos.GraphingCalculator(
@@ -43,7 +41,6 @@ class DesmosActivityGraph extends Component {
         });
         updatedTabs[this.props.currentTab] = updatedTab;
       }
-      console.log("tab switched");
       this.calculator.setState(
         this.props.activity.tabs[this.props.currentTab].currentState
       );

--- a/client/src/Containers/Workspace/DesmosActivityGraph.js
+++ b/client/src/Containers/Workspace/DesmosActivityGraph.js
@@ -3,15 +3,12 @@ import classes from "./graph.css";
 import Aux from "../../Components/HOC/Auxil";
 import Modal from "../../Components/UI/Modal/Modal";
 import Script from "react-load-script";
-import socket from "../../utils/sockets";
 import API from "../../utils/apiRequests";
 // import { updatedRoom } from '../../store/actions';
 class DesmosActivityGraph extends Component {
   state = {
-    loading: window.Desmos ? false : true,
-    receivingEvent: false
+    loading: window.Desmos ? false : true
   };
-
   calculatorRef = React.createRef();
 
   componentDidMount() {
@@ -30,102 +27,64 @@ class DesmosActivityGraph extends Component {
         API.getDesmos(tabs[currentTab].desmosLink)
           .then(res => {
             this.calculator.setState(res.data.result.state);
-            // this.initializeListeners();
           })
           .catch(err => console.log(err));
       }
-      this.initializeListeners();
     }
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (nextProps.currentTab !== this.props.currentTab) {
-      return true;
-    } else return false;
+  componentDidUpdate(prevProps) {
+    if (prevProps.currentTab !== this.props.currentTab) {
+      if (this.props.role === "facilitator") {
+        let updatedTabs = [...prevProps.activity.tabs];
+        let updatedTab = updatedTabs[prevProps.currentTab];
+        updatedTab.currentState = JSON.stringify({
+          ...this.calculator.getState()
+        });
+        updatedTabs[this.props.currentTab] = updatedTab;
+      }
+      console.log("tab switched");
+      this.calculator.setState(
+        this.props.activity.tabs[this.props.currentTab].currentState
+      );
+    }
   }
 
   componentWillUnmount() {
+    // save on unmount
+    if (this.props.role === "facilitator") {
+      let updatedTabs = [...this.props.activity.tabs];
+      let updatedTab = updatedTabs[this.props.currentTab];
+      updatedTab.currentState = JSON.stringify({
+        ...this.calculator.getState()
+      });
+      updatedTabs[this.props.currentTab] = updatedTab;
+    }
     this.calculator.unobserveEvent("change");
     this.calculator.destroy();
   }
 
-  componentDidUpdate(prevProps) {
-    console.log(prevProps, this.props);
-    console.log("UPDATED");
-    if (prevProps.currentTab !== this.props.currentTab) {
-      console.log("setting state");
-      this.setState({ receivingEvent: true }, () => {
-        let { room, currentTab } = this.props;
-        let { tabs } = room;
-        if (tabs[currentTab].currentState) {
-          this.calculator.setState(tabs[currentTab].currentState);
-        } else if (tabs[currentTab].desmosLink) {
-          API.getDesmos(tabs[currentTab].desmosLink)
-            .then(res => {
-              this.calculator.setState(res.data.result.state);
-              this.initializeListeners();
-            })
-            .catch(err => console.log(err));
-        }
-      });
-    }
-  }
-
   onScriptLoad = () => {
-    console.log("script loaded");
-    if (!this.calculator) {
-      this.calculator = window.Desmos.GraphingCalculator(
-        this.calculatorRef.current
-      );
-    }
+    this.calculator = window.Desmos.GraphingCalculator(
+      this.calculatorRef.current
+    );
     let { activity, currentTab } = this.props;
     let { tabs } = activity;
     let { desmosLink } = tabs[currentTab];
     if (tabs[currentTab].currentState) {
       this.calculator.setState(tabs[currentTab].currentState);
       this.setState({ loading: false });
-      this.initializeListeners();
     } else if (desmosLink) {
-      // @TODO This will require some major reconfiguration / But what we shoould do is
-      // when the user creates this room get teh state from the link and then just save it
-      // as as event on this model.
       API.getDesmos(desmosLink)
         .then(res => {
           this.calculator.setState(res.data.result.state);
-          // console.
           this.setState({ loading: false });
-          this.initializeListeners();
+          // this.initializeListeners();
         })
         .catch(err => console.log(err));
     } else {
-      this.initializeListeners();
       this.setState({ loading: false });
     }
-  };
-
-  // componentWillUnmount(){
-  //   console.log("componentUNMOUNTING")
-  // }
-
-  initializeListeners = () => {
-    console.log("listeners");
-    // INITIALIZE EVENT LISTENER
-    this.calculator.observeEvent("change", event => {
-      console.log("EVENT: ", event);
-      if (this.props.role === "facilitator") {
-        console.log("updating calc state");
-        let updatedTabs = [...this.props.activity.tabs];
-        let updatedTab = updatedTabs[this.props.currentTab];
-        updatedTab.currentState = this.calculator.getState();
-        updatedTab.currentState = JSON.stringify({
-          ...updatedTab.currentState
-        });
-        updatedTabs[this.props.currentTab] = updatedTab;
-        this.props.updateActivityTab(this.props.activity._id, updatedTab._id, {
-          currentState: updatedTab.currentState
-        });
-      }
-    });
   };
 
   render() {

--- a/client/src/Containers/Workspace/DesmosGraph.js
+++ b/client/src/Containers/Workspace/DesmosGraph.js
@@ -121,7 +121,6 @@ class DesmosGraph extends Component {
         };
         let updatedTabs = [...this.props.room.tabs];
         updatedTabs[this.props.currentTab].currentState = newData.currentState;
-        // console.log('sending event')
         this.props.updatedRoom(this.props.room._id, { tabs: updatedTabs });
         socket.emit("SEND_EVENT", newData, res => {
           this.props.resetControlTimer();


### PR DESCRIPTION
closes #151 

We may want to look more into this. We're not having the same issue for desmos graphs as we are for desmos activity graphs. The only difference between those components is that desmos activity graph updates the tab directly 

```javascript
this.props.updateActivityTab(this.props.activity._id, updatedTab._id, {
   currentState: updatedTab.currentState
});
```

while the room graph updates all of the tabs...

```javascript
this.props.updatedRoom(this.props.room._id, { tabs: updatedTabs });
```

it seems like only the first way of updating (just the one tab) was causing the issue described in #151 