### PR TITLE
fetch user on appLoad

### DIFF
--- a/client/src/Components/HOC/SocketProvider.js
+++ b/client/src/Components/HOC/SocketProvider.js
@@ -22,16 +22,19 @@ class SocketProvider extends Component {
   };
   componentDidMount() {
     if (this.props.user.loggedIn) {
+      this.props.getUser(this.props.user._id);
       // console.log(socket._callbacks)
       socket.on("connect", () => {
         let userId = this.props.user._id;
         let socketId = socket.id;
+        console.log("synching socket");
         socket.emit("SYNC_SOCKET", { socketId, userId }, (res, err) => {
           if (err) {
             //something went wrong updatnig user socket
             // HOW SHOULD WE HANDLE THIS @TODO
             return;
           }
+          console.log(res);
           this.props.updateUser({ connected: true });
         });
         this.initializeListeners();


### PR DESCRIPTION
#173 was missing a fetchUser call on SocketProvide componentDidMount(); 
If the user is already logged in (because their session hasnt expired) when they arrive at vmt, we might not have their most recent notification so we should fetch the user every time a logged in user lands on the homepage. 