### PR TITLE
Optional auto play and forced stop time for goToTime function

### DIFF
--- a/client/src/Containers/Replayer/EncompassReplayer.js
+++ b/client/src/Containers/Replayer/EncompassReplayer.js
@@ -1,11 +1,11 @@
-import React, { Component } from "react";
-import ReactDOM from "react-dom";
-import classes from "./EncompassReplayer.css";
-import SharedReplayer from "./SharedReplayer";
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import classes from './EncompassReplayer.css';
+import SharedReplayer from './SharedReplayer';
 
 class EncompassReplayer extends Component {
   state = {
-    room: null
+    room: null,
   };
 
   componentDidMount() {
@@ -13,11 +13,11 @@ class EncompassReplayer extends Component {
     let roomId = this.getRoomIdFromUrl(currentUrl);
     this.setState({ room: this.getRoomFromWindow(roomId) });
 
-    window.addEventListener("hashchange", this.setRoom, false);
+    window.addEventListener('hashchange', this.setRoom, false);
   }
 
   componentWillUnmount() {
-    window.removeEventListener("hashchange", this.setRoom);
+    window.removeEventListener('hashchange', this.setRoom);
   }
 
   setRoom = event => {
@@ -28,11 +28,11 @@ class EncompassReplayer extends Component {
   };
 
   getRoomIdFromUrl = url => {
-    if (typeof url !== "string") {
+    if (typeof url !== 'string') {
       return null;
     }
 
-    let target = "vmtRoomId=";
+    let target = 'vmtRoomId=';
     let targetIx = url.indexOf(target);
     let roomId;
 
@@ -49,16 +49,12 @@ class EncompassReplayer extends Component {
     return window.vmtRooms[roomId] || null;
   };
 
-  onLoad = (replayerState, totalDuration) => {
+  updateEncompass = (messageType, replayerState, totalDuration) => {
     window.postMessage({
-      messageType: 'VMT_ON_REPLAYER_LOAD',
+      messageType,
+      vmtReplayerInfo: { ...replayerState, totalDuration },
     });
-    this.updateEncompass(replayerState, totalDuration);
-  }
-
-  updateEncompass = (replayerState, totalDuration) => {
-    window.vmtReplayerInfo = {...replayerState, totalDuration };
-  }
+  };
 
   render() {
     if (this.state.room) {
@@ -67,7 +63,6 @@ class EncompassReplayer extends Component {
           <SharedReplayer
             room={this.state.room}
             updateEnc={this.updateEncompass}
-            onLoadEnc={this.onLoad}
             encompass
           />
         </div>
@@ -78,4 +73,4 @@ class EncompassReplayer extends Component {
   }
 }
 
-ReactDOM.render(<EncompassReplayer />, document.getElementById("root"));
+ReactDOM.render(<EncompassReplayer />, document.getElementById('root'));


### PR DESCRIPTION
Add optional arguments doAutoPlay and stopTime to goToTime function

When Encompass user clicks on a vmt selection in encompass, a message will be sent to vmt instructing vmt to invoke goToTime with doAutoPlay=true and stopTime equal to the vmt selection's end time.

This way the replayer will immediately start replaying the selected selection and automatically stop when the end is reached