### PR TITLE
Bug/stats no data

### DIFF
--- a/client/src/Components/Loading/Loading.js
+++ b/client/src/Components/Loading/Loading.js
@@ -1,27 +1,52 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classes from './loading.css';
 import sine from './sine.gif';
 
-const Loading = ({ message, isSmall }) => {
-  return (
+const Loading = ({ message, isSmall, waitTimeMs }) => {
+  const [doDisplay, setDisplay] = useState(false);
+
+  const [timer, setTimer] = useState(false);
+
+  useEffect(() => {
+    if (!timer) {
+      const timeout = setTimeout(() => {
+        if (!doDisplay) {
+          setDisplay(true);
+        }
+      }, waitTimeMs);
+
+      setTimer(timeout);
+    }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+        setTimer(null);
+      }
+    };
+  });
+
+  return doDisplay ? (
     <div className={!isSmall ? classes.Loading : classes.SmallLoading}>
       <div className={classes.Graph}>
         <img src={sine} height={20} width={100} alt="...loading" />
       </div>
       <div className={classes.Message}>{message}</div>
     </div>
-  );
+  ) : null;
 };
 
 Loading.propTypes = {
   message: PropTypes.string,
   isSmall: PropTypes.bool,
+  waitTimeMs: PropTypes.number,
 };
 
 Loading.defaultProps = {
   message: null,
   isSmall: false,
+  waitTimeMs: 100,
 };
 
 export default Loading;

--- a/client/src/Containers/Stats/Stats.js
+++ b/client/src/Containers/Stats/Stats.js
@@ -19,36 +19,41 @@ import ToolTip from '../../Components/ToolTip/ToolTip';
 import InfoBox from '../../Components/InfoBox/InfoBox';
 
 const Stats = ({ populatedRoom }) => {
+  const hasLog = populatedRoom.log.length > 0;
+
   const [state, dispatch] = useReducer(statsReducer, initialState);
   const [isResizing, setResizing] = useState(false);
   const debounceResize = useCallback(debounce(() => setResizing(false), 1000));
   let chart;
   const { inChartView, filteredData } = state;
-  if (populatedRoom.log && !isResizing && inChartView) {
+
+  if (hasLog && !isResizing && inChartView) {
     chart = <Chart state={state} />;
-  } else if (populatedRoom.log && !isResizing) {
+  } else if (hasLog && !isResizing) {
     chart = <Table data={filteredData} />;
   } else {
     chart = <Loading isSmall />;
   }
 
-  useEffect(() => {
-    dispatch({ type: 'GENERATE_DATA', data: populatedRoom.log });
-  }, [populatedRoom.log]);
+  if (hasLog) {
+    useEffect(() => {
+      dispatch({ type: 'GENERATE_DATA', data: populatedRoom.log });
+    }, [populatedRoom.log]);
 
-  // resize
-  useEffect(() => {
-    const handleResize = () => {
-      setResizing(true);
-      debounceResize();
-    };
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  });
+    // resize
+    useEffect(() => {
+      const handleResize = () => {
+        setResizing(true);
+        debounceResize();
+      };
+      window.addEventListener('resize', handleResize);
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    });
+  }
 
-  return (
+  return hasLog ? (
     <div>
       <InfoBox
         title={`${populatedRoom.name} activity`}
@@ -95,6 +100,10 @@ const Stats = ({ populatedRoom }) => {
       <InfoBox title="Filters" icon={<i className="fas fa-filter" />}>
         <Filters data={populatedRoom} filters={state} dispatch={dispatch} />
       </InfoBox>
+    </div>
+  ) : (
+    <div data-testid="no-data-message">
+      This room does not have any activity yet.
     </div>
   );
 };

--- a/server/cypress/integration/dataViz.js
+++ b/server/cypress/integration/dataViz.js
@@ -1,4 +1,5 @@
 import user8 from '../fixtures/user8';
+import user from '../fixtures/user';
 
 describe('Data Visualization', function() {
   before(function() {
@@ -92,5 +93,25 @@ describe('Data Visualization', function() {
       .should('not.be.visible')
       .should('have.attr', 'href')
       .and('include', 'blob:http://localhost');
+  });
+});
+
+describe('Visiting stats page for a room with no recorded data', function() {
+  const roomId = '5ba289c57223b9429888b9b5';
+  const roomName = 'room 1';
+
+  before(function() {
+    cy.login(user);
+    cy.contains(roomName).click();
+    cy.contains('Stats').click();
+  });
+
+  after(function() {
+    cy.logout();
+  });
+
+  it('Should display no data message', function() {
+    cy.url().should('include', `/myVMT/rooms/${roomId}/stats`);
+    cy.getTestElement('no-data-message').should('exist');
   });
 });

--- a/server/cypress/integration/workspace.js
+++ b/server/cypress/integration/workspace.js
@@ -24,7 +24,7 @@ describe('Workspace/replayer', function() {
       .contains('jl_picard joined room 1')
       .should('be.visible');
     cy.getTestElement('take-control').click();
-    cy.wait(5000);
+    cy.wait(1000);
     cy.getTestElement('take-control').click();
     cy.get(':nth-child(5) > .toolbar_button > .gwt-Image').click();
     cy.getTestElement('control-warning').should('be.visible');


### PR DESCRIPTION
Fixed bug occurring when loading a room with no activity
  - Now displays an info message 
  -- Added basic e2e test

Added a default timeout to the Loading component to try to avoid "flashing" when load times are almost instantaneous - i.e. when clicking on the stats tab from a room page.

  -- Not sure how well this is working when loading a workspace. It seems like it is waiting longer than the default 100ms before displaying the loading message. This may have something to do with the fact that the Loading component is rendering twice?