### PR TITLE
Desmos ref

### DIFF
--- a/client/src/Components/Chat/Message.js
+++ b/client/src/Components/Chat/Message.js
@@ -61,6 +61,7 @@ const Message = React.forwardRef((props, ref) => {
             onKeyPress={onClick}
             role="button"
             tabIndex="0"
+            data-testid={`msg-${id}`}
           >
             {message.text}
           </span>

--- a/client/src/Components/UI/Modal/CheckboxModal.js
+++ b/client/src/Components/UI/Modal/CheckboxModal.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+import classes from './modal.css';
+import Button from '../Button/Button';
+import { Checkbox } from '../..';
+
+class CheckboxModal extends Component {
+  onSelect(event) {
+    const { onSelect } = this.props;
+
+    if (onSelect) {
+      onSelect(event);
+    }
+  }
+  render() {
+    const {
+      show,
+      closeModal,
+      infoMessage,
+      isChecked,
+      checkboxDataId,
+    } = this.props;
+
+    return (
+      <Modal show={show} closeModal={closeModal}>
+        <div>{infoMessage}</div>
+        <div className={classes.Row}>
+          <Checkbox
+            change={(event) => {
+              this.onSelect(event);
+            }}
+            checked={isChecked}
+            dataId={checkboxDataId}
+          >
+            Do not show me this message again
+          </Checkbox>
+        </div>
+
+        <div className={classes.Row}>
+          <Button m={10} click={closeModal}>
+            Okay
+          </Button>
+        </div>
+      </Modal>
+    );
+  }
+}
+
+CheckboxModal.defaultProps = {
+  isChecked: false,
+  checkboxDataId: null,
+};
+
+CheckboxModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  infoMessage: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  isChecked: PropTypes.bool,
+  checkboxDataId: PropTypes.string,
+};
+export default CheckboxModal;

--- a/client/src/Containers/Community.js
+++ b/client/src/Containers/Community.js
@@ -50,12 +50,20 @@ class Community extends Component {
     const { resource } = match.params;
     // when switching between resources and filters,
     // we should reset skip back to 0
+    // reset search text
     if (prevProps.match.params.resource !== resource) {
-      this.setState({ skip: 0 }, () => {
+      this.setState({ skip: 0, searchText: '' }, () => {
         this.fetchData();
       });
     } else if (location.search !== prevProps.location.search) {
-      this.setState({ skip: 0 }, () => {
+      const stateHash = { skip: 0 };
+
+      if (location.search.indexOf('search=') === -1) {
+        // search query was cleared from url so search input needs to be cleared
+        // happens when clicking community top bar
+        stateHash.searchText = '';
+      }
+      this.setState(stateHash, () => {
         this.fetchData();
       });
     }

--- a/client/src/Containers/Replayer/DesmosReplayer.js
+++ b/client/src/Containers/Replayer/DesmosReplayer.js
@@ -97,7 +97,7 @@ class DesmosReplayer extends Component {
 DesmosReplayer.propTypes = {
   inView: PropTypes.bool.isRequired,
   log: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  index: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired,
   tab: PropTypes.shape({}).isRequired,
   setTabLoaded: PropTypes.func.isRequired,
 };

--- a/client/src/Containers/Room.js
+++ b/client/src/Containers/Room.js
@@ -23,7 +23,8 @@ import {
   populateRoom,
   removeRoomMember,
   clearLoadingInfo,
-  // populateRoom
+  // populateRoom,
+  updateUser,
 } from '../store/actions';
 import {
   Aux,
@@ -298,6 +299,7 @@ class Room extends Component {
       connectClearError,
       connectUpdateRoom,
       course,
+      connectUpdateUser,
     } = this.props;
     const {
       guestMode,
@@ -626,6 +628,9 @@ class Room extends Component {
         error={error}
         clearError={connectClearError}
         setAdmin={() => {
+          connectUpdateUser({
+            inAdminMode: !user.inAdminMode,
+          });
           this.setState({ isAdmin: true, guestMode: false });
         }}
       />
@@ -651,6 +656,7 @@ Room.propTypes = {
   connectRemoveRoomMember: PropTypes.func.isRequired,
   connectClearLoadingInfo: PropTypes.func.isRequired,
   connectPopulateRoom: PropTypes.func.isRequired,
+  connectUpdateUser: PropTypes.func.isRequired,
 };
 
 Room.defaultProps = {
@@ -683,5 +689,6 @@ export default connect(
     connectRemoveRoomMember: removeRoomMember,
     connectClearLoadingInfo: clearLoadingInfo,
     connectPopulateRoom: populateRoom,
+    connectUpdateUser: updateUser,
   }
 )(Room);

--- a/client/src/Containers/Room.js
+++ b/client/src/Containers/Room.js
@@ -629,7 +629,7 @@ class Room extends Component {
         clearError={connectClearError}
         setAdmin={() => {
           connectUpdateUser({
-            inAdminMode: !user.inAdminMode,
+            inAdminMode: true,
           });
           this.setState({ isAdmin: true, guestMode: false });
         }}

--- a/client/src/Containers/Workspace/DesmosGraph.js
+++ b/client/src/Containers/Workspace/DesmosGraph.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Script from 'react-load-script';
 import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import classes from './graph.css';
 import ControlWarningModal from './ControlWarningModal';
 import socket from '../../utils/sockets';
@@ -159,8 +160,6 @@ class DesmosGraph extends Component {
     const { tab, updatedRoom, addNtfToTabs } = this.props;
     this.calculator.observeEvent('change', () => {
       const { room, user, myColor, resetControlTimer, inControl } = this.props;
-      // eslint-disable-next-line react/destructuring-assignment
-      // console.log("initializing ", this.initializing);
       if (this.initializing) return;
       if (this.undoing) {
         this.undoing = false;
@@ -189,6 +188,7 @@ class DesmosGraph extends Component {
             username: user.username,
           },
           timestamp: new Date().getTime(),
+          description: `${user.username} modified an expression`,
         };
         // Update the instanvce variables tracking desmos state so they're fresh for the next equality check
         socket.emit('SEND_EVENT', newData, () => {});
@@ -254,9 +254,12 @@ class DesmosGraph extends Component {
       }
       for (let x = 0; x < currentExpressionProps.length; x++) {
         const propName = currentExpressionProps[x];
+        // cant just use === because values may be objects
         if (
-          newState.expressions.list[i][propName] !==
-          this.expressionList[i][propName]
+          !isEqual(
+            newState.expressions.list[i][propName],
+            this.expressionList[i][propName]
+          )
         ) {
           return false;
         }
@@ -268,7 +271,7 @@ class DesmosGraph extends Component {
       // ignore changes to viewport property
       if (
         propName !== 'viewport' &&
-        newState[propName] !== this.graph[propName]
+        !isEqual(newState.graph[propName], this.graph[propName])
       ) {
         return false;
       }

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -11,6 +11,7 @@ import {
   updateRoomTab,
   setRoomStartingPoint,
   updateUser,
+  updateUserSettings,
 } from '../../store/actions';
 import mongoIdGenerator from '../../utils/createMongoId';
 import WorkspaceLayout from '../../Layout/Workspace/Workspace';
@@ -599,6 +600,7 @@ class Workspace extends Component {
       tempMembers,
       connectUpdateRoomTab,
       tempCurrentMembers,
+      connectUpdateUserSettings,
     } = this.props;
     const {
       tabs: currentTabs,
@@ -692,6 +694,8 @@ class Workspace extends Component {
             addNtfToTabs={this.addNtfToTabs}
             isFirstTabLoaded={isFirstTabLoaded}
             setFirstTabLoaded={() => this.setState({ isFirstTabLoaded: true })}
+            referencing={referencing}
+            updateUserSettings={connectUpdateUserSettings}
           />
         );
       }
@@ -808,6 +812,7 @@ Workspace.propTypes = {
   connectUpdatedRoom: PropTypes.func.isRequired,
   connectUpdateRoomTab: PropTypes.func.isRequired,
   connectSetRoomStartingPoint: PropTypes.func.isRequired,
+  connectUpdateUserSettings: PropTypes.func.isRequired,
 };
 
 Workspace.defaultProps = {
@@ -833,5 +838,6 @@ export default connect(
     connectUpdatedRoomTab: updatedRoomTab,
     connectUpdateRoomTab: updateRoomTab,
     connectSetRoomStartingPoint: setRoomStartingPoint,
+    connectUpdateUserSettings: updateUserSettings,
   }
 )(Workspace);

--- a/client/src/Layout/Homepage/Homepage.js
+++ b/client/src/Layout/Homepage/Homepage.js
@@ -90,7 +90,7 @@ class Homepage extends PureComponent {
               VMT is currently in Alpha. If you encounter bugs or want to
               suggest new features please email vmt@21pstem.org
             </p>
-            <p>last updated: 10.24.2019</p>
+            <p>last updated: 10.25.2019</p>
           </section>
           {/* <i onClick={this.scrollToDomRef} className={["fas fa-chevron-down", classes.Down].join(" ")}></i> */}
           <section className={classes.Options} ref={this.containerRef}>

--- a/client/src/Layout/Homepage/Homepage.js
+++ b/client/src/Layout/Homepage/Homepage.js
@@ -90,7 +90,7 @@ class Homepage extends PureComponent {
               VMT is currently in Alpha. If you encounter bugs or want to
               suggest new features please email vmt@21pstem.org
             </p>
-            <p>last updated: 10.25.2019</p>
+            <p>last updated: 10.28.2019</p>
           </section>
           {/* <i onClick={this.scrollToDomRef} className={["fas fa-chevron-down", classes.Down].join(" ")}></i> */}
           <section className={classes.Options} ref={this.containerRef}>

--- a/client/src/Layout/Homepage/Homepage.js
+++ b/client/src/Layout/Homepage/Homepage.js
@@ -90,7 +90,7 @@ class Homepage extends PureComponent {
               VMT is currently in Alpha. If you encounter bugs or want to
               suggest new features please email vmt@21pstem.org
             </p>
-            <p>last updated: 10.28.2019</p>
+            <p>last updated: 10.29.2019</p>
           </section>
           {/* <i onClick={this.scrollToDomRef} className={["fas fa-chevron-down", classes.Down].join(" ")}></i> */}
           <section className={classes.Options} ref={this.containerRef}>

--- a/client/src/Layout/Workspace/Workspace.js
+++ b/client/src/Layout/Workspace/Workspace.js
@@ -65,6 +65,17 @@ class WorkspaceLayout extends Component {
       ) {
         x2 = graphCoords.right - offSet;
       }
+    } else if (
+      referToCoords &&
+      referToEl &&
+      referToEl.elementType === 'chat_message'
+    ) {
+      // graphCoords is not being set for desmos
+      // but we want to be able to reference chat messages
+      // should graphCoords still be set even though we arent
+      // making whiteboard references?
+      y2 = referToCoords.top;
+      x2 = referToCoords.left;
     }
     let chatFlexGrow = 2;
     let membersFlexGrow = 1;

--- a/client/src/store/actions/index.js
+++ b/client/src/store/actions/index.js
@@ -14,6 +14,7 @@ export {
   forgotPassword,
   resetPassword,
   confirmEmail,
+  updateUserSettings,
 } from './user';
 export {
   fail,

--- a/client/src/store/actions/user.js
+++ b/client/src/store/actions/user.js
@@ -381,3 +381,14 @@ export const confirmEmail = (token) => {
       });
   };
 };
+
+export const updateUserSettings = (userId, updatedSettings) => {
+  return (dispatch) => {
+    dispatch(updateUser(updatedSettings));
+    API.put('user', userId, updatedSettings)
+      .then(() => {
+        // handle success?
+      })
+      .catch((err) => dispatch(loading.fail(err)));
+  };
+};

--- a/client/src/store/reducers/userReducer.js
+++ b/client/src/store/reducers/userReducer.js
@@ -22,6 +22,9 @@ const initialState = {
   ssoId: '',
   doForcePasswordChange: false,
   confirmEmailDate: null,
+  settings: {
+    doShowDesmosRefWarning: true,
+  },
 };
 
 const reducer = (state = initialState, action) => {

--- a/server/cypress/integration/community.js
+++ b/server/cypress/integration/community.js
@@ -300,87 +300,30 @@ describe('test community search and filter', function() {
   //   });
   // });
 
-  xdescribe('Searching', function() {
+  describe('Searching', function() {
     it('searches for a single room', function() {
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 9);
-      cy.getTestElement('community-search')
-        .click()
-        .type('reference');
-      cy.wait(1000);
+      clickResourceTab('rooms');
+      checkItemsLength(rooms.all.length);
+      doSearch('reference');
       cy.url().should(
         'include',
-        'community/rooms?privacy=all&roomType=all&search='
+        'community/rooms?privacy=all&roomType=all&search=reference'
       );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 1);
+      checkItemsLength(1);
       cy.contains('reference room').should('exist');
     });
 
-    it('filters privacy setting', function() {
-      cy.getTestElement('community-search').clear();
-      cy.wait(1000);
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 9);
-      cy.getTestElement('public-filter').click();
-      cy.url().should(
-        'include',
-        'community/rooms?privacy=public&roomType=all&search='
-      );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 3);
-      cy.getTestElement('private-filter').click();
-      cy.url().should(
-        'include',
-        'community/rooms?privacy=private&roomType=all&search='
-      );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 6);
-      cy.getTestElement('all-privacy-filter').click();
-      cy.url().should(
-        'include',
-        'community/rooms?privacy=all&roomType=all&search='
-      );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 9);
+    it('Changing resource tab should clear search text', function() {
+      clickResourceTab('activities');
+      cy.getTestElement('community-search').should('have.value', '');
+      clickResourceTab('rooms');
     });
 
-    it('filters room type', function() {
-      cy.getTestElement('community-search').clear();
-      cy.wait(1000);
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 9);
-      cy.getTestElement('geogebra-filter').click();
-      cy.url().should(
-        'include',
-        'community/rooms?privacy=all&roomType=geogebra&search='
-      );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 9);
-      cy.getTestElement('desmos-filter').click();
-      cy.url().should(
-        'include',
-        'community/rooms?privacy=all&roomType=desmos&search='
-      );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 0); // @todo update the seed data so we have a desmos room
-      cy.getTestElement('all-roomType-filter').click();
-      cy.url().should(
-        'include',
-        'community/rooms?privacy=all&roomType=all&search='
-      );
-      cy.getTestElement('box-list')
-        .children()
-        .should('have.length', 9);
+    xit('Clicking community tab should clear search text', function() {
+      doSearch('reference');
+      cy.getTestElement('community-search').should('have.value', 'reference');
+      cy.getTestElement('nav-Community').click({ force: true });
+      cy.getTestElement('community-search').should('have.value', '');
     });
 
     // @todo test that we can search by description or instructions

--- a/server/cypress/integration/referencing.js
+++ b/server/cypress/integration/referencing.js
@@ -1,34 +1,82 @@
 import user8 from '../fixtures/user8';
+import ssmith from '../fixtures/user9';
+
+function toggleReferencing() {
+  cy.getTestElement('new-reference').click({ force: true });
+}
 
 describe('Referencing', function() {
-  before(function() {
-    cy.task('restoreAll').then(() => cy.login(user8));
+  describe('Geogebra', function() {
+    before(function() {
+      cy.task('restoreAll').then(() => cy.login(user8));
+    });
+
+    after(function() {
+      cy.logout();
+    });
+
+    it('loads a workspace', function() {
+      cy.get('#Rooms').click();
+      cy.getTestElement('content-box-reference room').click();
+      cy.getTestElement('Enter').click();
+      cy.wait(3000);
+      cy.getTestElement('chat')
+        .children()
+        .should('have.length', 23);
+    });
+    it('shows a reference when clicking on reference message', () => {
+      cy.getTestElement('reference-line').should('not.be.visible');
+      cy.getTestElement('5d0d2f0748e22b165488897c').click();
+      cy.getTestElement('reference-line').should('be.visible');
+    });
+
+    it('makes a new reference', () => {
+      toggleReferencing();
+      cy.getTestElement('reference-line').should('not.be.visible');
+      cy.getTestElement('msg-5d0d2f0748e22b165488897c').click();
+      cy.getTestElement('reference-line').should('be.visible');
+    });
   });
 
-  after(function() {
-    cy.logout();
-  });
+  describe('Desmos Referencing', function() {
+    before(function() {
+      cy.login(ssmith);
+      cy.get('#Rooms').click();
+      cy.contains('ssmith public desmos').click();
+      cy.getTestElement('Enter').click();
+    });
 
-  it('loads a workspace', function() {
-    cy.get('#Rooms').click();
-    cy.getTestElement('content-box-reference room').click();
-    cy.wait(500);
-    cy.getTestElement('Enter').click();
-    cy.wait(3000);
-    cy.getTestElement('chat')
-      .children()
-      .should('have.length', 23);
-  });
-  it('shows a reference when clicking on reference message', () => {
-    cy.getTestElement('reference-line').should('not.be.visible');
-    cy.getTestElement('5d0d2f0748e22b165488897c').click();
-    cy.getTestElement('reference-line').should('be.visible');
-  });
+    it('properly handles whiteboard referencing modal', function() {
+      // no modal should appear if referencing is off
+      cy.get('.dcg-grapher').click();
+      cy.getTestElement('ref-warning-checkbox').should('not.be.visible');
 
-  it('makes a new reference', () => {
-    cy.getTestElement('new-reference').click({ force: true });
-    cy.getTestElement('reference-line').should('not.be.visible');
-    cy.getTestElement('5d0d2f0748e22b165488897c').click();
-    cy.getTestElement('reference-line').should('be.visible');
+      toggleReferencing();
+
+      cy.get('.dcg-grapher').click();
+      cy.getTestElement('ref-warning-checkbox').should('be.visible');
+      cy.getTestElement('ref-warning-checkbox').should('not.be.checked');
+      cy.contains('Okay').click();
+      cy.getTestElement('ref-warning-checkbox').should('not.be.visible');
+
+      // check box to prevent future modals for this message
+      cy.get('.dcg-grapher').click();
+      cy.getTestElement('ref-warning-checkbox').click();
+      cy.contains('Okay').click();
+
+      cy.get('.dcg-grapher').click();
+      cy.getTestElement('ref-warning-checkbox').should('not.be.visible');
+
+      // reload to make sure the updated user setting is being persisted
+      cy.reload();
+      cy.get('.dcg-grapher').click();
+      cy.getTestElement('ref-warning-checkbox').should('not.be.visible');
+    });
+
+    it('makes a new chat reference', () => {
+      cy.getTestElement('reference-line').should('not.be.visible');
+      cy.getTestElement('msg-5d8e1c9583074a44e85d97e0').click();
+      cy.getTestElement('reference-line').should('be.visible');
+    });
   });
 });

--- a/server/middleware/api.js
+++ b/server/middleware/api.js
@@ -299,7 +299,10 @@ const prunePutBody = (user, recordIdToUpdate, body, details) => {
   const { isCreator, isFacilitator, modelName } = details;
   const copy = Object.assign({}, body);
   if (modelName === 'User') {
-    const isUpdatingSelf = _.isEqual(user._id, recordIdToUpdate);
+    const isUpdatingSelf = helpers.areObjectIdsEqual(
+      user._id,
+      recordIdToUpdate
+    );
     if (!isUpdatingSelf) {
       // can only modify another user's notifications
       return _.pick(

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -32,6 +32,9 @@ const User = new mongoose.Schema(
     isEmailConfirmed: { type: Boolean, default: false },
     doForcePasswordChange: { type: Boolean, default: false },
     confirmEmailDate: { type: Date },
+    settings: {
+      doShowDesmosRefWarning: { type: Boolean, default: true },
+    },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
Fixed desmos chat message referencing 
Display modal informing user that whiteboard (graph) referencing is not available for desmos
Give option for user to check box so message will not appear again (saved in their user settings, which is also new)
