### PR TITLE
Storing state of rooms with base64

### DIFF
--- a/client/src/Components/Chat/Chat.js
+++ b/client/src/Components/Chat/Chat.js
@@ -56,8 +56,6 @@ class Chat extends Component {
       setToElAndCoords,
       referToEl,
       showingReference,
-      // referenceElement,
-      // referenceElementCoords,
     } = this.props;
     if (prevProps.log.length !== log.length) {
       // create a ref for the new element
@@ -80,14 +78,13 @@ class Chat extends Component {
       setToElAndCoords(null, this.getRelativeCoords(refMessage));
     } else if (prevProps.referencing && !referencing) {
       this.setState({ highlightedMessage: null });
+    } else if (prevProps.showingReference && !showingReference) {
+      // need to set the from el to the chatinput just as if we started referencing
+      setFromElAndCoords(
+        this.chatInput.current,
+        this.getRelativeCoords(this.chatInput.current)
+      );
     }
-    //  else if (
-    //   !prevProps.referenceElementCoords &&
-    //   referenceElementCoords &&
-    //   referenceElement.elementType === 'chat_message'
-    // ) {
-
-    // }
   }
 
   componentWillUnmount() {
@@ -173,7 +170,12 @@ class Chat extends Component {
 
   // If the object being reference is a chat message (and not an element on the graph)
   referToMessage = (event, id) => {
-    const { setToElAndCoords } = this.props;
+    const { setToElAndCoords, showingReference, clearReference } = this.props;
+
+    if (showingReference) {
+      clearReference({ doKeepReferencingOn: true });
+    }
+
     const position = this.getRelativeCoords(event.target);
     setToElAndCoords({ element: id, elementType: 'chat_message' }, position);
   };

--- a/client/src/Components/Navigation/HomeNav/HomeNav.js
+++ b/client/src/Components/Navigation/HomeNav/HomeNav.js
@@ -62,7 +62,7 @@ const Navbar = ({ page, user, loggedIn, isDark, toggleAdmin }) => {
               name="Community"
             />
             <NavItem link="/about" name="About" />
-            <NavItem link="/tutorials" name="Tutorials" />
+            {/* <NavItem link="/tutorials" name="Tutorials" /> */}
             {loggedIn ? (
               <DropdownNavItem
                 name={

--- a/client/src/Components/Navigation/NavItem/NavItem.js
+++ b/client/src/Components/Navigation/NavItem/NavItem.js
@@ -19,11 +19,13 @@ const NavItem = ({ name, link, ntf, sliderDetails }) => {
     style = classes.ActiveLink;
   }
 
+  const dataName = typeof name === 'string' ? name : 'profile';
+
   if (sliderDetails) {
     const { isOn, onClick } = sliderDetails;
     return (
       <div className={style}>
-        <Checkbox checked={isOn} change={onClick} dataId={`nav-${name}`}>
+        <Checkbox checked={isOn} change={onClick} dataId={`nav-${dataName}`}>
           {name}
         </Checkbox>
       </div>
@@ -31,7 +33,11 @@ const NavItem = ({ name, link, ntf, sliderDetails }) => {
   }
   return (
     <div className={style}>
-      <NavLink data-testid={`nav-${name}`} className={classes.link} to={link}>
+      <NavLink
+        data-testid={`nav-${dataName}`}
+        className={classes.link}
+        to={link}
+      >
         {name}
       </NavLink>
       {ntf ? <Notification size="small" /> : null}

--- a/client/src/Containers/Create/NewTabForm.js
+++ b/client/src/Containers/Create/NewTabForm.js
@@ -119,7 +119,10 @@ class NewTabForm extends Component {
         closeModal();
       })
       .catch(() => {
-        // DISPLAY THIS ERROR MESSAGE: @TODO
+        this.setState({
+          errorMessage:
+            'Sorry, an error occured. Please try reloading the page.',
+        });
       });
   };
 
@@ -203,8 +206,8 @@ NewTabForm.propTypes = {
   updatedActivity: PropTypes.func,
   sendEvent: PropTypes.func,
   closeModal: PropTypes.func.isRequired,
-  setTabs: PropTypes.func.isRequired,
-  currentTabs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  setTabs: PropTypes.func, // not used for activities
+  currentTabs: PropTypes.arrayOf(PropTypes.shape({})), // not used for activities
 };
 
 NewTabForm.defaultProps = {
@@ -212,5 +215,7 @@ NewTabForm.defaultProps = {
   updatedActivity: null,
   sendEvent: null,
   activity: null,
+  setTabs: null,
+  currentTabs: null,
 };
 export default NewTabForm;

--- a/client/src/Containers/Replayer/GgbReplayer.js
+++ b/client/src/Containers/Replayer/GgbReplayer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Script from 'react-load-script';
@@ -5,12 +6,14 @@ import classes from '../Workspace/graph.css';
 
 import { getEventXml } from './SharedReplayer.utils';
 import { isNonEmptyArray } from '../../utils/objects';
+import { setGgbBase64Async } from '../Workspace/ggbUtils';
 
 class GgbReplayer extends Component {
   graph = React.createRef();
   isFileSet = false; // calling ggb.setBase64 triggers this.initializeGgb(), because we set base 64 inside initializeGgb we use this instance var to track whether we've already set the file. When the ggb tries to load the file twice it breaks everything
 
   elementXmlBeforeRemovalHash = {};
+  backwardsBase64Hash = {};
 
   componentDidMount() {
     window.addEventListener('resize', this.updateDimensions);
@@ -61,12 +64,12 @@ class GgbReplayer extends Component {
 
   // We should periodically save the entire state so if we skip to the very end we don't have to apply each event one at a time
 
-  constructEvent = (data) => {
+  constructEvent = async (data) => {
     const { ggbEvent, eventArray } = data;
     if (eventArray && eventArray.length > 0) {
-      this.recursiveUpdateNew(eventArray);
+      await this.recursiveUpdateNew(eventArray, data._id);
     } else if (ggbEvent) {
-      this.writeGgbEventToGraph(ggbEvent);
+      await this.writeGgbEventToGraph(ggbEvent, data._id);
     }
     // return;
     // switch (eventType) {
@@ -160,7 +163,7 @@ class GgbReplayer extends Component {
       errorDialogsActive: false,
       preventFocus: true,
       appletOnLoad: this.initializeGgb,
-      appName: tab.appName,
+      appName: tab.appName, // doesn't need to be required because ggb default is 'classic'
     };
     const ggbApp = new window.GGBApplet(parameters, '5.0');
     ggbApp.inject(`ggb-element${tabId}A`);
@@ -170,7 +173,11 @@ class GgbReplayer extends Component {
     const { tabId, tab, setTabLoaded } = this.props;
     this.ggbApplet = window[`ggbApplet${tabId}A`];
     setTabLoaded(tab._id);
-    this.ggbApplet.setMode(40); // Sets the tool to zoom
+
+    // do we need to set the mode here?
+    // the toolbar is not visible and once we load the starting point or file
+    // the tool gets set automatically
+
     const { startingPoint, ggbFile } = tab;
     // put the current construction on the graph, disable everything until the user takes control
     // if (perspective) this.ggbApplet.setPerspective(perspective);
@@ -191,65 +198,83 @@ class GgbReplayer extends Component {
     }
   };
 
-  writeGgbEventToGraph = (event) => {
-    const { eventType } = event;
+  writeGgbEventToGraph = async (event, eventId) => {
+    try {
+      // eventId is the Event model id
+      const { eventType } = event;
 
-    if (eventType === 'REMOVE') {
-      const { label } = event;
+      if (eventType === 'REMOVE') {
+        const { label } = event;
 
-      if (!event.isUndoAdd) {
-        const cachedXmlStack = this.elementXmlBeforeRemovalHash[label];
+        if (!event.isUndoAdd) {
+          const cachedXmlStack = this.elementXmlBeforeRemovalHash[label];
 
-        if (!Array.isArray(cachedXmlStack)) {
-          // no removed items with this label have been cached
-          this.elementXmlBeforeRemovalHash[label] = [];
+          if (!Array.isArray(cachedXmlStack)) {
+            // no removed items with this label have been cached
+            this.elementXmlBeforeRemovalHash[label] = [];
 
-          const elementXml = this.ggbApplet.getXML(label);
-          if (elementXml) {
-            this.elementXmlBeforeRemovalHash[label].push(elementXml);
+            const elementXml = this.ggbApplet.getXML(label);
+            if (elementXml) {
+              this.elementXmlBeforeRemovalHash[label].push(elementXml);
+            }
+          } else {
+            const elementXml = this.ggbApplet.getXML(label);
+            if (elementXml) {
+              this.elementXmlBeforeRemovalHash[label].push(elementXml);
+            }
           }
+        }
+        this.ggbApplet.deleteObject(label);
+      } else if (event.isUndoRename) {
+        // have to reset the renamed object to old label
+        this.ggbApplet.renameObject(event.label, event.oldLabel);
+      } else if (event.xml) {
+        this.ggbApplet.evalXML(event.xml);
+      } else if (eventType === 'ADD' && event.isUndoRemove) {
+        const cachedXmlStack = this.elementXmlBeforeRemovalHash[event.label];
+
+        if (isNonEmptyArray(cachedXmlStack)) {
+          const cachedXml = this.elementXmlBeforeRemovalHash[event.label].pop();
+
+          if (cachedXml) {
+            this.ggbApplet.evalXML(cachedXml);
+          }
+        }
+      } else if (
+        event.commandString &&
+        event.objType !== 'point' &&
+        event.eventType !== 'DRAG'
+      ) {
+        this.ggbApplet.evalCommand(event.commandString);
+        // if (event.valueString) {
+        //   this.ggbApplet.evalCommand(event.valueString);
+        // }
+      } else if (event.commandString) {
+        const test = this.ggbApplet.evalCommandGetLabels(event.commandString);
+        if (event.label) {
+          this.ggbApplet.renameObject(test, event.label);
+        }
+      } else if (event.base64) {
+        let base64ToSet;
+        if (event.isForBackwards) {
+          base64ToSet = this.backwardsBase64Hash[eventId];
+          delete this.backwardsBase64Hash[eventId];
         } else {
-          const elementXml = this.ggbApplet.getXML(label);
-          if (elementXml) {
-            this.elementXmlBeforeRemovalHash[label].push(elementXml);
-          }
+          base64ToSet = event.base64;
+          this.backwardsBase64Hash[eventId] = this.ggbApplet.getBase64();
+        }
+
+        if (base64ToSet) {
+          this.didSetBase64 = true;
+          await setGgbBase64Async(this.ggbApplet, base64ToSet);
+        } else {
+          return;
         }
       }
-      this.ggbApplet.deleteObject(label);
-    } else if (event.isUndoRename) {
-      // have to reset the renamed object to old label
-      this.ggbApplet.renameObject(event.label, event.oldLabel);
-    } else if (event.xml) {
-      this.ggbApplet.evalXML(event.xml);
-    } else if (eventType === 'ADD' && event.isUndoRemove) {
-      const cachedXmlStack = this.elementXmlBeforeRemovalHash[event.label];
-
-      if (isNonEmptyArray(cachedXmlStack)) {
-        const cachedXml = this.elementXmlBeforeRemovalHash[event.label].pop();
-
-        if (cachedXml) {
-          this.ggbApplet.evalXML(cachedXml);
-        }
-        console.log('found cachedXml for event: ', 'event', event, cachedXml);
-      } else {
-        console.log('missing cached xml for ', event);
-      }
-    } else if (
-      event.commandString &&
-      event.objType !== 'point' &&
-      event.eventType !== 'DRAG'
-    ) {
-      this.ggbApplet.evalCommand(event.commandString);
-      // if (event.valueString) {
-      //   this.ggbApplet.evalCommand(event.valueString);
-      // }
-    } else if (event.commandString) {
-      const test = this.ggbApplet.evalCommandGetLabels(event.commandString);
-      if (event.label) {
-        this.ggbApplet.renameObject(test, event.label);
-      }
+      this.ggbApplet.evalCommand('UpdateConstruction()');
+    } catch (err) {
+      console.log(`Error writing ggb event to graph: `, err);
     }
-    this.ggbApplet.evalCommand('UpdateConstruction()');
   };
 
   /**
@@ -259,84 +284,28 @@ class GgbReplayer extends Component {
    * @param  {} endIndex
    */
 
-  applyMultipleEvents(startIndex, endIndex) {
+  async applyMultipleEvents(startIndex, endIndex) {
     const { log } = this.props;
     // Forwards through time
     if (startIndex < endIndex) {
-      // this.ggbApplet.setXML(this.props.log[endIndex].currentState);
-      console.log(
-        'applying multiple forwards',
-        'from ',
-        startIndex,
-        'to ',
-        endIndex
-      );
-
-      for (let i = startIndex; i <= endIndex; i++) {
+      // if we were paused on ix 2 and then click to index 5,
+      // we will have already applied the event for ix 2
+      for (let i = startIndex + 1; i <= endIndex; i++) {
         const syntheticEvent = { ...log[i] };
-        // const { eventType } = syntheticEvent;
-        // const isNewEvent = typeof eventType !== 'string';
-
-        // if (isNewEvent) {
         const { ggbEvent, eventArray } = syntheticEvent;
         if (eventArray && eventArray.length > 0) {
-          this.recursiveUpdateNew(eventArray);
+          await this.recursiveUpdateNew(eventArray);
         } else if (ggbEvent) {
-          this.writeGgbEventToGraph(ggbEvent);
-        } else {
-          // console.log('ELSE shouldnt be here: ', syntheticEvent);
+          await this.writeGgbEventToGraph(ggbEvent, syntheticEvent._id);
         }
-        // } else if (
-        //   log[i].eventArray &&
-        //   log[i].eventArray.length > 0 &&
-        //   getEventType(log[i]) === 'BATCH_UPDATE'
-        // ) {
-        //   const { eventArray } = syntheticEvent;
-
-        //   const xmlOrGgbEvent = eventArray.pop();
-
-        //   setEventXml(syntheticEvent, xmlOrGgbEvent);
-        //   setEventType(syntheticEvent, 'UPDATE');
-
-        //   console.log('calling constructEvent from applyMult');
-        //   this.constructEvent(syntheticEvent);
-        // } else {
-        //   console.log('calling constructEvent from applyMult else');
-        //   this.constructEvent(log[i]);
-        // }
       }
     }
 
     // backwards through time
     else {
-      console.log(
-        'applying multiple backwards',
-        'from ',
-        startIndex,
-        'to ',
-        endIndex
-      );
       for (let i = startIndex; i > endIndex; i--) {
         const syntheticEvent = { ...log[i] };
-        // const { eventType } = syntheticEvent;
-        // const isNewEvent = typeof eventType !== 'string';
-
-        // if (isNewEvent) {
-        const {
-          ggbEvent,
-          eventArray,
-          // undoArray,
-          // undoGgbEvent,
-        } = syntheticEvent;
-
-        // if (isNonEmptyArray(undoArray)) {
-        //   console.log({ undoArray });
-        //   this.recursiveUpdateNew([...undoArray]);
-        // } else if (undoGgbEvent) {
-        //   console.log({ undoGgbEvent });
-        //   this.writeGgbEventToGraph(undoGgbEvent);
-        // } else
-
+        const { ggbEvent, eventArray } = syntheticEvent;
         if (eventArray && eventArray.length > 0) {
           const syntheticEvents = eventArray.map((ev) => {
             const copy = { ...ev };
@@ -349,13 +318,14 @@ class GgbReplayer extends Component {
             } else if (evType === 'REMOVE') {
               copy.eventType = 'ADD';
               copy.isUndoRemove = true;
-              // look for undoXML
             } else if (evType === 'RENAME') {
               copy.isUndoRename = true;
+            } else if (copy.base64) {
+              copy.isForBackwards = true;
             }
             return copy;
           });
-          this.recursiveUpdateNew(syntheticEvents);
+          await this.recursiveUpdateNew(syntheticEvents);
         } else if (ggbEvent) {
           const copy = { ...ggbEvent };
           if (copy.eventType === 'ADD') {
@@ -368,27 +338,11 @@ class GgbReplayer extends Component {
             copy.isUndoRemove = true;
           } else if (copy.eventType === 'RENAME') {
             copy.isUndoRename = true;
+          } else if (copy.base64) {
+            copy.isForBackwards = true;
           }
-          this.writeGgbEventToGraph(copy);
+          await this.writeGgbEventToGraph(copy, syntheticEvent._id);
         }
-        // } else {
-        //   if (eventType === 'ADD') {
-        //     setEventType(syntheticEvent, 'REMOVE');
-        //   } else if (eventType === 'REMOVE') {
-        //     syntheticEvent.undoRemove = true;
-        //     setEventType(syntheticEvent, 'ADD');
-        //   } else if (eventType === 'BATCH_ADD') {
-        //     setEventType(syntheticEvent, 'BATCH_REMOVE');
-        //   } else if (eventType === 'BATCH_UPDATE') {
-        //     const { eventArray } = { ...syntheticEvent };
-
-        //     const xmlOrGgbEvent = eventArray.shift();
-
-        //     setEventXml(syntheticEvent, xmlOrGgbEvent);
-        //     setEventType(syntheticEvent, 'UPDATE');
-        //   }
-        //   this.constructEvent(syntheticEvent);
-        // }
       }
     }
   }
@@ -436,18 +390,21 @@ class GgbReplayer extends Component {
     }
   }
 
-  recursiveUpdateNew(events) {
+  async recursiveUpdateNew(events, eventId) {
     if (Array.isArray(events) && events.length > 0) {
       const copiedEvents = [...events];
 
       const event = copiedEvents.shift();
-      this.writeGgbEventToGraph(event);
+      await this.writeGgbEventToGraph(event, eventId);
       if (copiedEvents.length > 0) {
         // readyToClearSocketQueue = false;
         // By wrapping calls to recursiveUpdate in a setTimeout we end up with behavior that is closer
         // to a natural dragging motion. If we write copy one after the other w/o a timeout
         // the point moves too quickly and looks like its jumping to the final position
-        setTimeout(() => this.recursiveUpdateNew(copiedEvents), 0);
+        setTimeout(
+          async () => this.recursiveUpdateNew(copiedEvents, eventId),
+          0
+        );
       }
     }
     // if (readyToClearSocketQueue) {
@@ -480,7 +437,7 @@ GgbReplayer.propTypes = {
   isFullscreen: PropTypes.bool.isRequired,
   setTabLoaded: PropTypes.func.isRequired,
   tab: PropTypes.shape({
-    appName: PropTypes.string.isRequired,
+    appName: PropTypes.string,
     _id: PropTypes.string.isRequired,
     startinPoint: PropTypes.string,
     ggbFile: PropTypes.string,

--- a/client/src/Containers/Replayer/GgbReplayer.js
+++ b/client/src/Containers/Replayer/GgbReplayer.js
@@ -439,7 +439,7 @@ GgbReplayer.propTypes = {
   tab: PropTypes.shape({
     appName: PropTypes.string,
     _id: PropTypes.string.isRequired,
-    startinPoint: PropTypes.string,
+    startingPoint: PropTypes.string,
     ggbFile: PropTypes.string,
   }).isRequired,
   tabId: PropTypes.number.isRequired,

--- a/client/src/Containers/Workspace/ActivityWorkspace.js
+++ b/client/src/Containers/Workspace/ActivityWorkspace.js
@@ -174,12 +174,10 @@ class ActivityWorkspace extends Component {
           <WorkspaceLayout
             graphs={graphs}
             tabs={tabs}
-            // activeMember={this.state.activeMember}
             roomName={activity.name} // THIS IS NO GOOD...WE SHOULD CHANGE THE ROOM ATTR TO RESOURCE THAT CAN ACCEPT EITHER A ROOM OR AN ACTIVITY
             user={user}
             role={role} // oh shit role is taken...its for a11y  stuff
             currentTabId={currentTabId || initialTabId}
-            // updateRoom={this.props.updateRoom}
             bottomRight={
               <ActivityTools
                 owner={role === 'facilitator'}
@@ -214,7 +212,7 @@ class ActivityWorkspace extends Component {
           <NewTabForm
             activity={activity}
             closeModal={this.closeModal}
-            updatedRoom={connectUpdatedActivity}
+            updatedActivity={connectUpdatedActivity}
             user={user}
           />
         </Modal>

--- a/client/src/Containers/Workspace/ControlWarningModal.js
+++ b/client/src/Containers/Workspace/ControlWarningModal.js
@@ -7,10 +7,10 @@ const ControlWarningModal = ({
   takeControl,
   cancel,
   showControlWarning,
-  toggleControlWarning,
+  // toggleControlWarning,
 }) => {
   return (
-    <Modal show={showControlWarning} closeModal={toggleControlWarning}>
+    <Modal show={showControlWarning} closeModal={cancel}>
       <div data-testid="control-warning">
         You can&#39;t make updates when you&#39;re not in control click
         &#34;Take Control&#34; first.
@@ -32,7 +32,7 @@ ControlWarningModal.propTypes = {
   showControlWarning: PropTypes.bool.isRequired,
   takeControl: PropTypes.func.isRequired,
   cancel: PropTypes.func.isRequired,
-  toggleControlWarning: PropTypes.func.isRequired,
+  // toggleControlWarning: PropTypes.func.isRequired,
 };
 
 export default ControlWarningModal;

--- a/client/src/Containers/Workspace/GgbActivityGraph.js
+++ b/client/src/Containers/Workspace/GgbActivityGraph.js
@@ -18,7 +18,9 @@ class GgbActivityGraph extends Component {
         // eslint-disable-next-line no-unused-vars
         const { role, tab, activity, updateActivityTab } = this.props;
         if (role === 'facilitator' && this.ggbApplet) {
-          API.put('tabs', tab._id, { currentState: this.ggbApplet.getXML() })
+          API.put('tabs', tab._id, {
+            currentStateBase64: this.ggbApplet.getBase64(),
+          })
             .then(() => {})
             .catch((err) => {
               // eslint-disable-next-line no-console
@@ -160,7 +162,7 @@ class GgbActivityGraph extends Component {
       // "0 39 73 62 | 1 501 67 , 5 19 , 72 75 76 | 2 15 45 , 18 65 , 7 37 | 4 3 8 9 , 13 44 , 58 , 47 | 16 51 64 , 70 | 10 34 53 11 , 24  20 22 , 21 23 | 55 56 57 , 12 | 36 46 , 38 49  50 , 71  14  68 | 30 29 54 32 31 33 | 25 17 26 60 52 61 | 40 41 42 , 27 28 35 , 6",
       showToolBar: role === 'facilitator',
       showMenuBar: role === 'facilitator',
-      showAlgebraInput: true,
+      showAlgebraInput: false,
       language: 'en',
       useBrowserForJS: false,
       borderColor: '#ddd',
@@ -188,9 +190,12 @@ class GgbActivityGraph extends Component {
     const { tab, user, activity, setFirstTabLoaded } = this.props;
     this.ggbApplet = window.ggbApplet;
     // this.setState({ loading: false });
-    const { currentState, startingPoint, ggbFile } = tab;
+    const { currentState, startingPoint, ggbFile, currentStateBase64 } = tab;
     //
-    if (currentState) {
+    if (currentStateBase64 && !this.isFileLoaded) {
+      this.isFileLoaded = true;
+      this.ggbApplet.setBase64(currentStateBase64);
+    } else if (currentState) {
       this.ggbApplet.setXML(currentState);
     } else if (startingPoint) {
       this.ggbApplet.setXML(startingPoint);

--- a/client/src/Containers/Workspace/GgbActivityGraph.js
+++ b/client/src/Containers/Workspace/GgbActivityGraph.js
@@ -5,7 +5,6 @@ import Script from 'react-load-script';
 import { parseString } from 'xml2js';
 import throttle from 'lodash/throttle';
 import { Aux } from '../../Components';
-import API from '../../utils/apiRequests';
 import classes from './graph.css';
 
 class GgbActivityGraph extends Component {
@@ -15,18 +14,12 @@ class GgbActivityGraph extends Component {
     super(props);
     this.getGgbState = throttle(
       () => {
-        // eslint-disable-next-line no-unused-vars
-        const { role, tab, activity, updateActivityTab } = this.props;
+        const { role, tab, updateActivityTab, activity } = this.props;
         if (role === 'facilitator' && this.ggbApplet) {
-          API.put('tabs', tab._id, {
-            currentStateBase64: this.ggbApplet.getBase64(),
-          })
-            .then(() => {})
-            .catch((err) => {
-              // eslint-disable-next-line no-console
-              console.log(err);
-            });
-          // this.props.updatedActivity(this.props.activity._id, {tabs: updatedTabs})
+          const base64 = this.ggbApplet.getBase64();
+          updateActivityTab(activity._id, tab._id, {
+            currentStateBase64: base64,
+          });
         } else {
           // eslint-disable-next-line no-alert
           window.alert(
@@ -41,54 +34,7 @@ class GgbActivityGraph extends Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.updateDimensions);
-    // if (window.ggbApplet) {
-    //   this.initializeGgb();
-    // }
   }
-
-  // componentDidUpdate(prevProps, prevState) {
-  //   // if (prevProps.currentTab !== this.props.currentTab) {
-  //   //   // by wrapping this in a setimteout of 0 I'm attempting to delay all of the event blocking geogebra operations
-  //   //   // until after any UI updates////can't quite tell if it working...when switching tab the tab animation should be smoothe
-  //   //   setTimeout(() => {
-  //   //     let {
-  //   //       currentState,
-  //   //       startingPoint,
-  //   //       ggbFile,
-  //   //       perspective
-  //   //     } = this.props.tabs[this.props.currentTab];
-  //   //     if (perspective) this.ggbApplet.setPerspective(perspective);
-  //   //     initPerspectiveListener(document, perspective, this.perspectiveChanged);
-  //   //     if (currentState) {
-  //   //       this.ggbApplet.setXML(currentState);
-  //   //       this.registerListeners();
-  //   //     } else if (startingPoint) {
-  //   //       this.ggbApplet.setXML(startingPoint);
-  //   //       this.registerListeners();
-  //   //     } else if (ggbFile) {
-  //   //       this.ggbApplet.setBase64(ggbFile, () => {
-  //   //         this.getGgbState();
-  //   //         if (this.props.user._id === this.props.activity.creator) {
-  //   //           this.freezeElements(false);
-  //   //         }
-  //   //       });
-  //   //     } else {
-  //   //       // this.ggbApplet.setXML(INITIAL_GGB);
-  //   //       this.registerListeners();
-  //   //     }
-  //   //   }, 0);
-  //   //   // Waiting for the tabs to populate if they haven't akready
-  //   // } else if (!prevProps.tabs[0].name && this.props.tabs[0].name) {
-  //   //   this.initializeGgb();
-  //   // }
-  // }
-
-  // // shouldComponentUpdate(nextProps) {
-  // //   return (
-  // //     this.props.tabId === this.props.currentTab ||
-  // //     nextProps.tabId === nextProps.currentTab
-  // //   );
-  // // }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateDimensions);
@@ -98,8 +44,7 @@ class GgbActivityGraph extends Component {
     if (this.loadingTimer) {
       clearInterval(this.loadingTimer);
     }
-    if (this.ggbApplet && this.ggbApplet.listeners) {
-      // delete window.ggbApplet;
+    if (this.ggbApplet) {
       this.ggbApplet.unregisterAddListener(this.getGgbState);
       this.ggbApplet.unregisterUpdateListener(this.getGgbState);
       this.ggbApplet.unregisterRemoveListener(this.getGgbState);
@@ -109,37 +54,6 @@ class GgbActivityGraph extends Component {
     delete window.ggbApplet;
   }
 
-  // Save new state to the redux store on each modification to the construction
-  // When the user leaves the room we'll update the backend (that way we only do it once)
-
-  perspectiveChanged = (newPerspectiveCode) => {
-    const { tab, activity, updateActivityTab } = this.props;
-    updateActivityTab(activity._id, tab._id, {
-      perspective: newPerspectiveCode,
-    });
-
-    // // REinitialize listener with new perspective
-    // initPerspectiveListener(
-    //   document,
-    //   newPerspectiveCode,
-    //   this.perspectiveChanged
-    // );
-  };
-
-  // updateDimensions = () => {
-  //   const { loading } = this.state;
-  //   if (this.resizeTimer) {
-  //     clearTimeout(this.resizeTimer);
-  //   }
-  //   this.resizeTimer = setTimeout(async () => {
-  //     if (this.graph.current && !loading) {
-  //       const { clientHeight, clientWidth } = this.graph.current.parentElement;
-  //       window.ggbApplet.setSize(clientWidth, clientHeight);
-  //       // window.ggbApplet.evalCommand('UpdateConstruction()'
-  //     }
-  //     this.resizeTimer = undefined;
-  //   }, 200);
-  // };
   updateDimensions = async () => {
     const { tab } = this.props;
     if (this.graph.current && this.ggbApplet) {
@@ -154,9 +68,9 @@ class GgbActivityGraph extends Component {
   };
 
   onScriptLoad = () => {
-    const { role, tab, currentTab, isFirstTabLoaded } = this.props;
+    const { role, tab, currentTab } = this.props;
     const parameters = {
-      id: `ggb-element${tab._id}A`,
+      id: `ggbApplet${tab._id}A`,
       // "scaleContainerClasse": "graph",
       // customToolBar:
       // "0 39 73 62 | 1 501 67 , 5 19 , 72 75 76 | 2 15 45 , 18 65 , 7 37 | 4 3 8 9 , 13 44 , 58 , 47 | 16 51 64 , 70 | 10 34 53 11 , 24  20 22 , 21 23 | 55 56 57 , 12 | 36 46 , 38 49  50 , 71  14  68 | 30 29 54 32 31 33 | 25 17 26 60 52 61 | 40 41 42 , 27 28 35 , 6",
@@ -169,7 +83,6 @@ class GgbActivityGraph extends Component {
       buttonShadows: true,
       errorDialogsActive: false,
       preventFocus: true,
-      // filename: this.props.tabs[this.props.tabId].ggbFile || null,
       appletOnLoad: this.initializeGgb,
       appName: tab.appName || 'classic',
     };
@@ -178,6 +91,7 @@ class GgbActivityGraph extends Component {
       ggbApp.inject(`ggb-element${tab._id}A`);
     } else {
       this.loadingTimer = setInterval(() => {
+        const { isFirstTabLoaded } = this.props;
         if (isFirstTabLoaded) {
           ggbApp.inject(`ggb-element${tab._id}A`);
           clearInterval(this.loadingTimer);
@@ -187,12 +101,16 @@ class GgbActivityGraph extends Component {
   };
 
   initializeGgb = () => {
-    const { tab, user, activity, setFirstTabLoaded } = this.props;
-    this.ggbApplet = window.ggbApplet;
-    // this.setState({ loading: false });
+    const { tab, setFirstTabLoaded, currentTab } = this.props;
+    this.ggbApplet = window[`ggbApplet${tab._id}A`];
+
     const { currentState, startingPoint, ggbFile, currentStateBase64 } = tab;
-    //
-    if (currentStateBase64 && !this.isFileLoaded) {
+
+    if (currentStateBase64) {
+      if (this.isFileLoaded) {
+        this.registerListeners();
+        return;
+      }
       this.isFileLoaded = true;
       this.ggbApplet.setBase64(currentStateBase64);
     } else if (currentState) {
@@ -203,19 +121,10 @@ class GgbActivityGraph extends Component {
       this.isFileLoaded = true;
       this.ggbApplet.setBase64(ggbFile);
     }
-    //  else if (perspective) {
-    //   console.log("[erspecitve");
-    //   this.ggbApplet.setPerspective(perspective);
-    // }
-    if (user._id === activity.creator) {
-      // this.freezeElements(false);
-      // this.freezeElements(true)
-    } else {
-      // this.freezeElements(true);
-    }
     this.registerListeners();
-    setFirstTabLoaded();
-    // put the current construction on the graph, disable everything until the user takes control
+    if (currentTab === tab._id) {
+      setFirstTabLoaded();
+    }
   };
 
   parseXML = (xml) => {
@@ -227,23 +136,17 @@ class GgbActivityGraph extends Component {
     });
   };
 
-  // freezeElements = (freeze) => {
-  //   const allElements = this.ggbApplet.getAllObjectNames(); // WARNING ... THIS METHOD IS DEPRECATED
-  //   allElements.forEach((element) => {
-  //     // AS THE CONSTRUCTION GETS BIGGER THIS GETS SLOWER...SET_FIXED IS BLOCKING
-  //     this.ggbApplet.setFixed(element, freeze, true); // Unfix/fix all of the elements
-  //   });
-
-  //   this.ggbApplet.enableRightClick(!freeze);
-  //   this.ggbApplet.showToolBar(!freeze);
-  //   this.ggbApplet.setMode(freeze ? 40 : 0);
-  // };
-
   registerListeners() {
+    this.ggbApplet.unregisterAddListener(this.getGgbState);
+    this.ggbApplet.unregisterUpdateListener(this.getGgbState);
+    this.ggbApplet.unregisterRemoveListener(this.getGgbState);
+    this.ggbApplet.unregisterClearListener(this.getGgbState);
+    this.ggbApplet.unregisterClientListener(this.getGgbState);
+
     this.ggbApplet.registerAddListener(this.getGgbState);
     this.ggbApplet.registerUpdateListener(this.getGgbState);
     this.ggbApplet.registerRemoveListener(this.getGgbState);
-    this.ggbApplet.registerClickListener(this.getGgbState);
+    this.ggbApplet.registerClearListener(this.getGgbState);
     this.ggbApplet.registerClientListener(this.getGgbState);
   }
 
@@ -271,13 +174,12 @@ class GgbActivityGraph extends Component {
 GgbActivityGraph.propTypes = {
   role: PropTypes.string.isRequired,
   currentTab: PropTypes.string.isRequired,
-  // tabs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   user: PropTypes.shape({}).isRequired,
   activity: PropTypes.shape({}).isRequired,
   isFirstTabLoaded: PropTypes.bool.isRequired,
   setFirstTabLoaded: PropTypes.func.isRequired,
-  updateActivityTab: PropTypes.func.isRequired,
   tab: PropTypes.shape({}).isRequired,
+  updateActivityTab: PropTypes.func.isRequired,
 };
 
 export default GgbActivityGraph;

--- a/client/src/Containers/Workspace/GgbGraph.js
+++ b/client/src/Containers/Workspace/GgbGraph.js
@@ -287,16 +287,17 @@ class GgbGraph extends Component {
   }
 
   getBase64Async = () => {
-    // eslint-disable-next-line consistent-return
     return new Promise((resolve, reject) => {
       if (!this.ggbApplet) {
-        return reject(new Error('Missing ggbApplet'));
+        reject(new Error('Missing ggbApplet'));
+        return;
       }
       this.ggbApplet.getBase64((base64) => {
         if (!base64) {
-          return reject(new Error('Unable to get base64 construction state'));
+          reject(new Error('Unable to get base64 construction state'));
+          return;
         }
-        return resolve(base64);
+        resolve(base64);
       });
     });
   };
@@ -498,64 +499,6 @@ class GgbGraph extends Component {
           'An error occurred syncing the state of this room. It is recommended you refresh the page to avoid falling out of sync with other users.'
         );
       });
-    // const { tab } = this.props;
-    // return API.getById('tabs', tab._id)
-    //   .then((res) => {
-    //     return this.setGgbState(res.data.result);
-    //     // const {
-    //     //   currentState,
-    //     //   ggbFile,
-    //     //   startingPoint,
-    //     //   currentStateBase64,
-    //     // } = res.data.result;
-
-    //     // if (currentStateBase64) {
-    //     //   console.log('loading from currbase64 is file set: ', this.isFileSet);
-    //     //   if (!this.isFileSet) {
-    //     //     this.isFileSet = true;
-    //     //     this.ggbApplet.setBase64(currentStateBase64, () => {
-    //     //       this.registerListeners();
-    //     //       this.isResyncing = false;
-    //     //     });
-    //     //   } else {
-    //     //     this.isResyncing = false;
-    //     //   }
-    //     // } else if (currentState) {
-    //     //   console.log('loading from current state');
-    //     //   this.ggbApplet.setXML(currentState);
-    //     //   this.registerListeners();
-    //     //   this.isResyncing = false;
-    //     // } else if (startingPoint) {
-    //     //   console.log('loading from startingpoint');
-    //     //   this.ggbApplet.setXML(startingPoint);
-    //     //   this.registerListeners();
-    //     //   this.isResyncing = false;
-    //     // } else if (ggbFile && !this.isFileSet) {
-    //     //   console.log('loading from ggbFile');
-    //     //   this.isFileSet = true;
-    //     //   this.ggbApplet.setBase64(ggbFile, () => {
-    //     //     this.registerListeners();
-    //     //     this.isResyncing = false;
-    //     //   });
-    //     // } else {
-    //     //   this.isResyncing = false;
-    //     // }
-    //   })
-    //   .then(() => {
-    //     console.log('in then after setting ggb state');
-    //     this.registerListeners();
-    //     const { inControl } = this.props;
-    //     const expectedMode = inControl === 'ME' ? 0 : 40;
-    //     this.isResyncing = false;
-    //   })
-    //   .catch((err) => {
-    //     console.log('ERROR resyncing: ', 'failed to updated', err);
-    //     this.isResyncing = false;
-    //     // eslint-disable-next-line no-alert
-    //     window.alert(
-    //       'An error occurred syncing the state of this room. It is recommended you refresh the page to avoid falling out of sync with other users.'
-    //     );
-    //   });
   };
 
   getTabState = () => {
@@ -611,8 +554,6 @@ class GgbGraph extends Component {
       .catch((err) => {
         console.log('ERROR resyncing: ', 'failed to updated', err);
         this.isResyncing = false;
-        // eslint-disable-next-line no-alert
-
         throw err;
       });
   };
@@ -696,7 +637,7 @@ class GgbGraph extends Component {
     // 40 = TRANSLATEVIEW
     // 0 = MOVE
 
-    const { referencing } = this.props;
+    const { referencing, clearReference } = this.props;
     if (this.receivingData) {
       return;
     }
@@ -720,6 +661,10 @@ class GgbGraph extends Component {
           if (this.userCanEdit()) {
             // throttled because of a bug in Geogebra that causes this to fire twice
             this.throttledSendEvent({ eventType: 'MODE', label: event[2] });
+
+            if (referencing) {
+              clearReference();
+            }
             return;
             // if the user is not connected or not in control and they initisted this event (i.e. it didn't come in over the socket)
             // Then don't send this to the other users/=.

--- a/client/src/Containers/Workspace/GgbGraph.js
+++ b/client/src/Containers/Workspace/GgbGraph.js
@@ -1801,19 +1801,15 @@ class GgbGraph extends Component {
         return 0;
       }
 
-      console.log({ defaultViewId });
       if (inControl === 'ME') {
+        const { referencing } = this.props;
+
+        if (referencing) {
+          return GgbViewIdToPerspectiveMap[defaultViewId].defaultTool;
+        }
         return GgbViewIdToPerspectiveMap[defaultViewId].controlTool;
       }
-
       // not in control
-
-      const { referencing } = this.props;
-
-      if (referencing) {
-        return GgbViewIdToPerspectiveMap[defaultViewId].controlTool;
-      }
-      // not referencing
       return GgbViewIdToPerspectiveMap[defaultViewId].defaultTool;
     } catch (err) {
       console.log('error get default ggbMode:', err);

--- a/client/src/Containers/Workspace/GgbGraph.js
+++ b/client/src/Containers/Workspace/GgbGraph.js
@@ -516,44 +516,6 @@ class GgbGraph extends Component {
     return API.getById('tabs', tab._id)
       .then((res) => {
         return this.setGgbState(res.data.result);
-        // const {
-        //   currentState,
-        //   ggbFile,
-        //   startingPoint,
-        //   currentStateBase64,
-        // } = res.data.result;
-
-        // if (currentStateBase64) {
-        //   console.log('loading from currbase64 is file set: ', this.isFileSet);
-        //   if (!this.isFileSet) {
-        //     this.isFileSet = true;
-        //     this.ggbApplet.setBase64(currentStateBase64, () => {
-        //       this.registerListeners();
-        //       this.isResyncing = false;
-        //     });
-        //   } else {
-        //     this.isResyncing = false;
-        //   }
-        // } else if (currentState) {
-        //   console.log('loading from current state');
-        //   this.ggbApplet.setXML(currentState);
-        //   this.registerListeners();
-        //   this.isResyncing = false;
-        // } else if (startingPoint) {
-        //   console.log('loading from startingpoint');
-        //   this.ggbApplet.setXML(startingPoint);
-        //   this.registerListeners();
-        //   this.isResyncing = false;
-        // } else if (ggbFile && !this.isFileSet) {
-        //   console.log('loading from ggbFile');
-        //   this.isFileSet = true;
-        //   this.ggbApplet.setBase64(ggbFile, () => {
-        //     this.registerListeners();
-        //     this.isResyncing = false;
-        //   });
-        // } else {
-        //   this.isResyncing = false;
-        // }
       })
       .then(() => {
         this.registerListeners();
@@ -636,9 +598,6 @@ class GgbGraph extends Component {
    */
 
   clientListener = (event) => {
-    const { tab } = this.props;
-
-    console.log(`Client event and tab is ${tab.name}: `, event);
     if (!event) {
       // seems to happen if you click a bunch of points really quickly
       return;
@@ -1578,8 +1537,9 @@ class GgbGraph extends Component {
       window.alert(msg);
       return;
     }
-
-    const isViewVisible = this.isReferenceViewVisible(viewNum);
+    // old references will not have the viewNum prop
+    // 1 is the normal default view when only having 1 graph
+    const isViewVisible = this.isReferenceViewVisible(viewNum || 1);
 
     if (!isViewVisible) {
       const msg = `The containing view for object (${elementType} ${element}) is not currently visible.`;

--- a/client/src/Containers/Workspace/Tools/ActivityTools.js
+++ b/client/src/Containers/Workspace/Tools/ActivityTools.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import classes from './tools.css';
 
 const ActivityTools = (props) => {
-  const { owner, copy, save, goBack } = props;
+  const { owner, copy, goBack } = props;
   return (
     <div className={classes.Container}>
       <h3 className={classes.Title}>Tools</h3>
@@ -35,7 +35,7 @@ const ActivityTools = (props) => {
                 here
               </Link>
             </p>
-            <div className={classes.Save}>
+            {/* <div className={classes.Save}>
               <div
                 className={classes.SideButton}
                 role="button"
@@ -46,7 +46,7 @@ const ActivityTools = (props) => {
               >
                 save
               </div>
-            </div>
+            </div> */}
           </div>
         ) : (
           <div>
@@ -93,13 +93,13 @@ const ActivityTools = (props) => {
 
 ActivityTools.propTypes = {
   owner: PropTypes.bool.isRequired,
-  save: PropTypes.func,
+  // save: PropTypes.func,
   copy: PropTypes.func.isRequired,
   goBack: PropTypes.func.isRequired,
 };
 
-ActivityTools.defaultProps = {
-  save: null,
-};
+// ActivityTools.defaultProps = {
+//   save: null,
+// };
 
 export default ActivityTools;

--- a/client/src/Containers/Workspace/Tools/Awareness.js
+++ b/client/src/Containers/Workspace/Tools/Awareness.js
@@ -1,21 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-// import { Avatar, ToolTip, Aux } from "../../../Components";
 import classes from './tools.css';
 import ggbTools from './GgbIcons';
 
 class Awareness extends Component {
-  state = {
-    // showToolTip: false,
-  };
-
   shouldComponentUpdate(nextProps) {
     const { lastEvent } = nextProps;
-
     if (lastEvent) {
       if (
-        (lastEvent.messageType === 'TEXT' && !lastEvent.reference) ||
-        !lastEvent.description
+        lastEvent.messageType === 'TEXT' &&
+        (!lastEvent.reference || !lastEvent.description)
       ) {
         // only show messages with references && event descriptions
         return false;
@@ -29,20 +23,8 @@ class Awareness extends Component {
       return (
         <div className={classes.AwarenessDesc} data-testid="awareness-desc">
           {lastEvent.description || lastEvent.text || lastEvent.message}
-          <div
-            className={classes.AwarenessIcon}
-            // onMouseOver={() => this.setState({ showToolTip: true })}
-            // onFocus={() => this.setState({ showToolTip: true })}
-            // onMouseOut={() => this.setState({ showToolTip: false })}
-            // onBlur={() => this.setState({ showToolTip: false })}
-          >
+          <div className={classes.AwarenessIcon}>
             {lastEvent.action === 'mode' ? (
-              // <ToolTip
-              //   visible={this.state.showToolTip}
-              //   text={ggbTools[lastEvent.label].name
-              //     .toLowerCase()
-              //     .replace("_", " ")}
-              // >
               <img
                 data-testid="awareness-img"
                 src={ggbTools[lastEvent.label].image}

--- a/client/src/Containers/Workspace/Tools/GgbIcons/index.js
+++ b/client/src/Containers/Workspace/Tools/GgbIcons/index.js
@@ -657,4 +657,16 @@ export default {
     link: 'https://wiki.geogebra.org/en/Reflect_about_Plane_Tool',
     image: svg571,
   },
+  1001: {
+    name: 'Symbolic Evaluation',
+    link: 'https://wiki.geogebra.org/en/Evaluate_Tool',
+  },
+  1002: {
+    name: 'Numeric Evaluation',
+    link: 'https://wiki.geogebra.org/en/Numeric_Tool',
+  },
+  1003: {
+    name: 'Keep Input',
+    link: 'https://wiki.geogebra.org/en/Keep_Input_Tool',
+  },
 };

--- a/client/src/Containers/Workspace/Tools/Tools.js
+++ b/client/src/Containers/Workspace/Tools/Tools.js
@@ -27,7 +27,6 @@ const Tools = ({
     }
   }
 
-  const goToText = replayer ? 'Room' : 'Replayer';
   return (
     <div className={classes.Container}>
       {/* <h3 className={classes.Title}>Tools</h3> */}
@@ -80,7 +79,7 @@ const Tools = ({
         ) : null}
         {goToReplayer ? (
           <Button theme="xs" click={goToReplayer}>
-            Go to {goToText}
+            Open Replayer
             <span className={classes.ExternalLink}>
               <i className="fas fa-external-link-alt" />
             </span>

--- a/client/src/Containers/Workspace/ggbUtils.js
+++ b/client/src/Containers/Workspace/ggbUtils.js
@@ -85,3 +85,19 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export const blankEditorState = `{"content":"","caret":[0]}`;
+
+export const setGgbBase64Async = (ggbApplet, base64) => {
+  return new Promise((resolve, reject) => {
+    if (!ggbApplet || typeof base64 !== 'string') {
+      reject(new Error('Invalid arguments'));
+      return;
+    }
+    try {
+      ggbApplet.setBase64(base64, () => {
+        resolve(true);
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+};

--- a/client/src/Layout/Facilitator/Facilitator.js
+++ b/client/src/Layout/Facilitator/Facilitator.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import CustomLink from '../../Components/Navigation/CustomLink/CustomLink';
+// import CustomLink from '../../Components/Navigation/CustomLink/CustomLink';
 import NewResource from '../../Containers/Create/NewResource/NewResource';
 import classes from './facilitator.css';
 
@@ -48,35 +48,9 @@ class FacilitatorInstructions extends Component {
           <p className={classes.Tutorial}>
             What&#39;s the difference between an activity and a room? To learn
             about how VMT works, try one of our{' '}
-            <CustomLink to="tutorials">tutorials</CustomLink>
+            {/* <CustomLink to="tutorials">tutorials</CustomLink> */}
           </p>
         </div>
-        {/* <div className={[classes.Center, classes.Invite].join(' ')}>
-            <div className={classes.Cards}>
-              <div className={classes.Card}>
-                <NewResource resource={'activities'} intro/>
-              </div>
-              <div className={classes.Card}>
-                <NewResource resource={'courses'} intro/>
-              </div>
-              <div className={classes.Card}>
-                <NewResource resource={'rooms'} intro/>
-              </div>
-            </div>
-          </div>
-          <div className={[classes.Center, classes.Manage].join(' ')}>
-            <div className={classes.Cards}>
-              <div className={classes.Card}>
-                <NewResource resource={'activities'} intro/>
-              </div>
-              <div className={classes.Card}>
-                <NewResource resource={'courses'} intro/>
-              </div>
-              <div className={classes.Card}>
-                <NewResource resource={'rooms'} intro/>
-              </div>
-            </div>
-          </div> */}
       </div>
     );
   }

--- a/client/src/Layout/Homepage/Homepage.js
+++ b/client/src/Layout/Homepage/Homepage.js
@@ -20,9 +20,6 @@ class Homepage extends PureComponent {
         this.setState({ error: null });
       }, 2000);
     }
-    // API.get('activities').then(res => {
-    //   this.setState({ popularActivities: res.data.results });
-    // });
   }
 
   componentDidUpdate(prevProps) {
@@ -90,31 +87,9 @@ class Homepage extends PureComponent {
               VMT is currently in Alpha. If you encounter bugs or want to
               suggest new features please email vmt@21pstem.org
             </p>
-            <p>last updated: 11.08.2019</p>
+            <p>last updated: 11.13.2019</p>
           </section>
-          {/* <i onClick={this.scrollToDomRef} className={["fas fa-chevron-down", classes.Down].join(" ")}></i> */}
-          <section className={classes.Options} ref={this.containerRef}>
-            {/* <h3 className={classes.Subtitle}>Popular Activities</h3>
-            <BoxList list={this.state.popularActivities}/> */}
-            {/* <div className={classes.Geogebra}>
-              <img className={classes.GgbImage} src={GeogebraImg} alt='geogebra' />
-              <div>
-                <p className={classes.LongerBlurb}>GeoGebra is dynamic mathematics software for all levels of education that
-                  brings together geometry, algebra, spreadsheets, graphing, statistics and
-                  calculus in one easy-to-use package. GeoGebra is a rapidly expanding
-                  community of millions of users located in just about every country.
-                </p>
-                <Link to='https://www.geogebra.org'>Learn More</Link>
-              </div>
-            </div>
-            <div className={classes.Desmos}>
-              <img className={classes.DesmosImage} src={DesmosImg} alt='desmos' />
-              <p className={classes.LongerBlurb}>
-                Desmos is a free graphing calculator with a large community of teachers and students actively
-                building and sharing activities.
-              </p>
-            </div> */}
-          </section>
+          <section className={classes.Options} ref={this.containerRef} />
         </div>
       </Aux>
     );

--- a/client/src/Layout/Homepage/Homepage.js
+++ b/client/src/Layout/Homepage/Homepage.js
@@ -87,7 +87,7 @@ class Homepage extends PureComponent {
               VMT is currently in Alpha. If you encounter bugs or want to
               suggest new features please email vmt@21pstem.org
             </p>
-            <p>last updated: 11.13.2019</p>
+            <p>last updated: 11.14.2019</p>
           </section>
           <section className={classes.Options} ref={this.containerRef} />
         </div>

--- a/client/src/Layout/Workspace/Workspace.js
+++ b/client/src/Layout/Workspace/Workspace.js
@@ -136,29 +136,34 @@ class WorkspaceLayout extends Component {
             ) : null}
           </div>
           <div className={classes.Right}>
-            <div
-              className={classes.Chat}
-              style={{
-                flexGrow: chatFlexGrow,
-                flexBasis: chatFlexBasis,
-                maxHeight: isFirefox ? '66%' : 'auto',
-              }}
-            >
-              {chat}
-            </div>
+            {activity ? null : (
+              <div
+                className={classes.Chat}
+                style={{
+                  flexGrow: chatFlexGrow,
+                  flexBasis: chatFlexBasis,
+                  maxHeight: isFirefox ? '66%' : 'auto',
+                }}
+              >
+                {chat}
+              </div>
+            )}
+
             <div className={activity ? classes.ActivityTools : classes.Tools}>
               {bottomRight}
             </div>
-            <div
-              className={classes.Members}
-              style={{
-                flexGrow: membersFlexGrow,
-                flexBasis: membersFlexBasis,
-                maxHeight: isFirefox ? '20%' : 'auto',
-              }}
-            >
-              {currentMembers}
-            </div>
+            {activity ? null : (
+              <div
+                className={classes.Members}
+                style={{
+                  flexGrow: membersFlexGrow,
+                  flexBasis: membersFlexBasis,
+                  maxHeight: isFirefox ? '20%' : 'auto',
+                }}
+              >
+                {currentMembers}
+              </div>
+            )}
           </div>
           {referToCoords && referFromCoords ? (
             <div className={classes.ReferenceLine}>

--- a/client/src/utils/sockets.js
+++ b/client/src/utils/sockets.js
@@ -9,8 +9,6 @@ if (process.env.REACT_APP_STAGING) {
   url = process.env.REACT_APP_SERVER_URL_PRODUCTION;
 }
 
-// eslint-disable-next-line no-console
-console.log('SOCKET URL: ', url);
 const socket = io.connect(url);
 
 export default socket;

--- a/server/controllers/ActivityController.js
+++ b/server/controllers/ActivityController.js
@@ -29,7 +29,7 @@ module.exports = {
       initialFilter.privacySetting = filters.privacySetting;
     }
 
-    const aggregationPipeline = [
+    let aggregationPipeline = [
       { $match: initialFilter },
       {
         $project: {
@@ -52,7 +52,10 @@ module.exports = {
           as: 'creatorObject',
         },
       },
-      {
+    ];
+
+    if (criteria) {
+      aggregationPipeline.push({
         $match: {
           $or: [
             { name: criteria },
@@ -61,7 +64,9 @@ module.exports = {
             { 'creatorObject.username': criteria },
           ],
         },
-      },
+      });
+    }
+    aggregationPipeline = aggregationPipeline.concat([
       { $unwind: '$creatorObject' },
       {
         $lookup: {
@@ -99,7 +104,7 @@ module.exports = {
           'creator._id': '$creator._id',
         },
       },
-    ];
+    ]);
 
     if (filters.roomType) {
       aggregationPipeline.push({

--- a/server/controllers/CourseController.js
+++ b/server/controllers/CourseController.js
@@ -36,7 +36,7 @@ module.exports = {
       initialFilter.privacySetting = filters.privacySetting;
     }
 
-    const aggregationPipeline = [
+    let aggregationPipeline = [
       { $match: initialFilter },
       {
         $project: {
@@ -68,7 +68,10 @@ module.exports = {
       },
 
       { $unwind: '$facilitatorObject' },
-      {
+    ];
+
+    if (criteria) {
+      aggregationPipeline.push({
         $match: {
           $or: [
             { name: criteria },
@@ -77,7 +80,9 @@ module.exports = {
             { 'facilitatorObject.username': criteria },
           ],
         },
-      },
+      });
+    }
+    aggregationPipeline = aggregationPipeline.concat([
       {
         $group: {
           _id: '$_id',
@@ -106,7 +111,7 @@ module.exports = {
           'members.role': 1,
         },
       },
-    ];
+    ]);
 
     aggregationPipeline.push({ $sort: { updatedAt: -1 } });
 

--- a/server/controllers/RoomController.js
+++ b/server/controllers/RoomController.js
@@ -102,7 +102,7 @@ module.exports = {
       initialFilter.privacySetting = filters.privacySetting;
     }
 
-    const aggregationPipeline = [
+    let aggregationPipeline = [
       { $match: initialFilter },
       {
         $project: {
@@ -135,7 +135,10 @@ module.exports = {
       },
 
       { $unwind: '$facilitatorObject' },
-      {
+    ];
+
+    if (criteria) {
+      aggregationPipeline.push({
         $match: {
           $or: [
             { name: criteria },
@@ -144,7 +147,9 @@ module.exports = {
             { 'facilitatorObject.username': criteria },
           ],
         },
-      },
+      });
+    }
+    aggregationPipeline = aggregationPipeline.concat([
       {
         $group: {
           _id: '$_id',
@@ -197,7 +202,7 @@ module.exports = {
           'members.user._id': 1,
         },
       },
-    ];
+    ]);
 
     if (filters.roomType) {
       aggregationPipeline.push({

--- a/server/controllers/RoomController.js
+++ b/server/controllers/RoomController.js
@@ -265,6 +265,7 @@ module.exports = {
             desmosLink: body.desmosLink,
             currentState: tab.currentState,
             startingPoint: tab.currentState,
+            currentStateBase64: tab.currentStateBase64,
             tabType: tab.tabType,
             appName: tab.appName,
           });
@@ -285,7 +286,7 @@ module.exports = {
           new Tab({
             name: 'Tab 1',
             room: room._id,
-            startinpoint: ' ',
+            startingpoint: '',
             desmosLink: body.desmosLink,
             tabType: body.roomType || 'geogebra',
             appName: body.appName,

--- a/server/cypress/integration/admin.js
+++ b/server/cypress/integration/admin.js
@@ -1,5 +1,16 @@
 const Q = require('../fixtures/user7');
 
+const adminColor = 'rgb(255, 213, 73)';
+const normalColor = 'rgb(45, 145, 242)';
+
+const checkAdminMode = (isOn) => {
+  const color = isOn ? adminColor : normalColor;
+  cy.get('.fa-user')
+    .first()
+    .should('have.css', 'background-color')
+    .and('eq', color);
+};
+
 describe('test admin privileges', function() {
   before(function() {
     cy.task('restoreAll').then(() => cy.login(Q));
@@ -14,13 +25,14 @@ describe('test admin privileges', function() {
     cy.getTestElement('content-box-room 2').click();
     cy.getTestElement('view-as-admin').click();
     cy.url().should('include', 'myVMT/rooms/5ba289c57223b9429888b9b6/details');
+    checkAdminMode(true);
   });
 
   it('Q can edit and delete this room', function() {
     cy.getTestElement('edit-room').click();
     cy.getTestElement('edit-instructions').type('new instructions');
     cy.getTestElement('save-room').click();
-    cy.wait(1000);
+    // cy.wait(1000);
     cy.contains('new instructions').should('exist');
     cy.getTestElement('edit-room').click();
     cy.getTestElement('trash-room').click();
@@ -90,6 +102,7 @@ describe('test admin privileges', function() {
   });
 
   it('Q turns admin mode on for anonymous viewing', function() {
+    cy.getTestElement('edit-Off').click();
     cy.get('.fa-user')
       .first()
       .should('have.css', 'background-color')

--- a/server/cypress/integration/create.js
+++ b/server/cypress/integration/create.js
@@ -260,7 +260,7 @@ describe('create each type of resource', function() {
 
       // check that the file loaded
       // should be items in the left algebra panel
-      const numAlgebraPanelItems = 11;
+      const numAlgebraPanelItems = 10;
       cy.get('.gwt-TreeItem').should('have.length', numAlgebraPanelItems);
     });
   });

--- a/server/cypress/integration/workspace.js
+++ b/server/cypress/integration/workspace.js
@@ -96,16 +96,17 @@ describe('Workspace/replayer', function() {
     cy.getTestElement('cancel').click();
     cy.getTestElement('chat')
       .children()
-      .should('have.length', 4);
+      .should('have.length', 3); // no longer emitting event for selecting move tool after taking control
   });
   it('allows tool selection after taking control', function() {
     cy.getTestElement('take-control').click();
 
-    checkAwareness('jl_picard selected the move tool');
+    checkAwareness('jl_picard took control');
+
     cy.getTestElement('chat')
       .children()
       .children()
-      .should('have.length', 10);
+      .should('have.length', 8);
     cy.get(':nth-child(5) > .toolbar_button > .gwt-Image').click();
     cy.wait(500);
     cy.get(':nth-child(5) > .toolbar_button > .gwt-Image').click();
@@ -177,11 +178,10 @@ describe('Workspace/replayer', function() {
         cy.getTestElement('about-link').should('exist');
       });
 
-      it('Should give option to save activity', function() {
-        // does save button work?
-        // does the user have to change the activity to be able to save?
-        cy.getTestElement('save-activity').should('exist');
-      });
+      // activities are auto saved every time the construction is updated
+      // xit('Should give option to save activity', function() {
+      //   cy.getTestElement('save-activity').should('exist');
+      // });
 
       it('Should display current tab name', function() {
         cy.getTestElement('room-info-tab-name').should(

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -28,7 +28,8 @@ const ggbEvent = {
       'MODE',
     ],
   },
-  oldLabel: { type: String }, // used for RENAME events
+  oldLabel: { type: String }, // used for RENAME events,
+  base64: { type: String }, // additional files such as images get lost using xml
 };
 const Event = new mongoose.Schema({
   user: { type: ObjectId, ref: 'User' },

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -21,6 +21,7 @@ const Message = new mongoose.Schema({
     y: { type: Number },
     z: { type: Number },
     description: { type: String },
+    viewNum: { type: Number },
   },
   messageType: {
     type: String,

--- a/server/models/Tab.js
+++ b/server/models/Tab.js
@@ -8,6 +8,7 @@ const Tab = new mongoose.Schema(
     instructions: { type: String },
     tabType: { type: String, enum: ['geogebra', 'desmos'] },
     currentState: { type: String, default: '' },
+    currentStateBase64: { type: String, default: '' },
     ggbFile: { type: String }, // ggb base64 file
     desmosLink: { type: String },
     perspective: {
@@ -18,7 +19,7 @@ const Tab = new mongoose.Schema(
           const regex = /[ABCDGLST]/g;
           return regex.test(v);
         },
-        message: (props) => `${props.value} is not a valide perspective`,
+        message: (props) => `${props.value} is not a valid perspective`,
       },
     },
     events: {


### PR DESCRIPTION
Refactored to storing state of geogebra rooms using base64
 - prevents loss of additional files/images uploaded into room

Reenabled Undo/Redo for geogebra rooms

Use zoom tool for referencing in geogebra rooms instead of move tool 
  - now users who are not in control cannot move things around, even if they are referencing

Now emitting "changePerspective" events when users change perspectives, such as adding a 2nd graph or switching to spreadsheet mode"
 - could potentially add a more detailed description of which views were added or removed

Referencing works with multiple graphs visible 
  - There are still issues when emitting objects with multiple graphs visible 
  - The object may show up on wrong graph, but if the room is reloaded the object will be on the correct graph 

Various fixes to Geogebra Activities
 