### PR TITLE
Keep Focus When Entering Equation in Desmos Tab

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -163,7 +163,6 @@ class Workspace extends Component {
     const isReference = this.doesEventHaveReference(entry);
 
     const updateHash = { log: [...log, entry] };
-
     if (isReference) {
       const { eventsWithRefs } = this.state;
       updateHash.eventsWithRefs = [...eventsWithRefs, entry];
@@ -1058,7 +1057,7 @@ class Workspace extends Component {
           <TextInput
             show={isCreatingActivity}
             light
-            focus
+            focus={isCreatingActivity}
             name="new name"
             value={newName}
             change={(event) => {


### PR DESCRIPTION
fixes #288 
The render function for the Workspace Component (in client/src/Containers/Workspace.js) was resetting the focus of the page to an input field in the "create an activity" modal window every time it was called. 

This was causing the Desmos calculator to lose focus every time the user in control of the room made a change to the equation. Every change triggers the Workspace function `addToLog`, which updates the state, which triggers a re-render.

Now Workspace will only change the focus of the page if the state variable `isCreatingActivity` is true.