### PR TITLE
[Bug]Fix production ENC url

### DIFF
--- a/server/config/app-urls.js
+++ b/server/config/app-urls.js
@@ -72,7 +72,8 @@ module.exports.getEncIssuerId = () => {
   const envName = process.env.NODE_ENV;
 
   if (envName === 'production') {
-    return process.env.ENC_JWT_ISSUER_ID_PROD;
+    // return process.env.ENC_JWT_ISSUER_ID_PROD;
+    return `https://encompass.mathematicalthinking.org`;
   }
 
   if (envName === 'staging') {


### PR DESCRIPTION
Related to this [thread](https://mathematicalt-8xw5409.slack.com/archives/CL08R6U67/p1602780697000400?thread_ts=1602687668.011800&cid=CL08R6U67).

Issue:
Previous ENV variable changes to production server of enc and vmt caused a CORS error when importing vmt workspaces from encompass.

PR Fix:
Change will hardcode the correct encompass production url.
