### PR TITLE
Handle existing users on import

### DIFF
--- a/client/src/Components/UI/Backdrop/Backdrop.js
+++ b/client/src/Components/UI/Backdrop/Backdrop.js
@@ -15,6 +15,10 @@ const Backdrop = ({ show, clicked }) =>
 
 Backdrop.propTypes = {
   show: PropTypes.bool.isRequired,
-  clicked: PropTypes.func.isRequired,
+  clicked: PropTypes.func,
+};
+
+Backdrop.defaultProps = {
+  clicked: null,
 };
 export default Backdrop;

--- a/client/src/Layout/ClassCode/ClassCode.js
+++ b/client/src/Layout/ClassCode/ClassCode.js
@@ -263,7 +263,7 @@ class ClassCode extends Component {
                 </Fragment>
               </Modal>
               <Modal
-                show={memberToConf}
+                show={!!memberToConf} // might be undefined
                 closeModal={() => {
                   this.setState({ memberToConf: null });
                 }}

--- a/client/src/utils/validators.js
+++ b/client/src/utils/validators.js
@@ -84,10 +84,11 @@ export const validateBasicToken = (token) => {
   return validateSchema(basicTokenSchema, { token });
 };
 
-// returns false if no existing username; returns the user object if it does exist
-export const validateExistingUsername = async (username) => {
+// returns false if no existing value for the field; returns the user object if it does exist
+
+export const validateExistingField = async (field, value) => {
   return api
-    .get('user', { username })
+    .get('user', { [field]: value })
     .then((res) => {
       return (
         res.data &&
@@ -100,7 +101,7 @@ export const validateExistingUsername = async (username) => {
 };
 
 export const suggestUniqueUsername = (username) => {
-  const uniqueName = validateExistingUsername(username)
+  const uniqueName = validateExistingField('username', username)
     .then((isExisting) => {
       return !isExisting
         ? username


### PR DESCRIPTION
* Created facility to handle both new and existing users when importing from a file. If the username and email are both from the same existing user, that user is invited to the course. If there is a mismatch between the username and email (e.g., existing username but with a different email or vice versa), buttons are presented that allow the user to resolve the mismatch.
* If a user edits a cell of the table, that row is checked for validation errors.
* Cleaned up some propType errors