### PR TITLE
:tada: Attendance facility for monitoring

### DIFF
--- a/client/src/Components/CurrentMembers/CurrentMembers.js
+++ b/client/src/Components/CurrentMembers/CurrentMembers.js
@@ -10,8 +10,17 @@ function CurrentMembers({
   activeMember,
   expanded,
   toggleExpansion,
+  showTitle,
 }) {
   const [presentMembers, setPresentMembers] = useState([]);
+  const activeMembers = React.useRef([]);
+
+  // allow for there to be more than one active member
+  React.useEffect(() => {
+    if (Array.isArray(activeMember)) activeMembers.current = activeMember;
+    else if (!activeMember) activeMembers.current = [];
+    else activeMembers.current = [activeMember];
+  }, [activeMember]);
 
   React.useEffect(() => {
     // filter out any malformed members. Of course, this has the effect of potentially not showing someone who is there.
@@ -54,16 +63,18 @@ function CurrentMembers({
 
   return (
     <div className={classes.Container}>
-      <div
-        className={classes.Title}
-        onClick={_toggle}
-        onKeyPress={_toggle}
-        role="button"
-        tabIndex="-1"
-      >
-        Currently in this room
-        <div className={classes.Count}>{presentMembers.length}</div>
-      </div>
+      {showTitle && (
+        <div
+          className={classes.Title}
+          onClick={_toggle}
+          onKeyPress={_toggle}
+          role="button"
+          tabIndex="-1"
+        >
+          Currently in this room
+          <div className={classes.Count}>{presentMembers.length}</div>
+        </div>
+      )}
       <div
         className={expanded ? classes.Expanded : classes.Collapsed}
         data-testid="current-members"
@@ -75,7 +86,8 @@ function CurrentMembers({
               <div
                 className={[
                   classes.Avatar,
-                  activeMember && presMember.user._id === activeMember
+                  activeMembers.current &&
+                  activeMembers.current.includes(presMember.user._id)
                     ? classes.Active
                     : classes.Passive,
                 ].join(' ')}
@@ -97,14 +109,19 @@ CurrentMembers.propTypes = {
     PropTypes.oneOfType([PropTypes.shape({}), PropTypes.string])
   ).isRequired,
   members: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  activeMember: PropTypes.string,
+  activeMember: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.shape({})),
+    PropTypes.string,
+  ]),
   expanded: PropTypes.bool.isRequired,
+  showTitle: PropTypes.bool,
   toggleExpansion: PropTypes.func,
 };
 
 CurrentMembers.defaultProps = {
   activeMember: null,
   toggleExpansion: null,
+  showTitle: true,
 };
 
 export default CurrentMembers;

--- a/client/src/Components/UI/ToggleGroup/toggleGroup.css
+++ b/client/src/Components/UI/ToggleGroup/toggleGroup.css
@@ -8,7 +8,7 @@
 .ToggleGroup {
   display: flex;
   flex-direction: row;
-  width: 220px;
+  width: 300px;
   border: 3px solid lightBorder;
   font-size: inherit;
   border-radius: 10px;

--- a/client/src/Containers/Course.js
+++ b/client/src/Containers/Course.js
@@ -649,11 +649,16 @@ const mapStateToProps = (store, ownProps) => {
   const localCourse = store.courses.byId[course_id]
     ? populateResource(store, 'courses', course_id, ['activities', 'rooms'])
     : null;
-  // Ownprops.course is the course from the db given by withPopulatedCourse
+  // Ownprops.course is the course from the db given by withPopulatedCourse. It has all the activities and rooms in the course; the localCourse
+  // only has the resources that the user has access to.
   return {
     course:
       localCourse.myRole === 'facilitator'
-        ? { ...ownProps.course, myRole: 'facilitator' }
+        ? {
+            ...localCourse,
+            activities: ownProps.course.activities,
+            rooms: ownProps.course.rooms,
+          }
         : localCourse,
     activities: store.activities.allIds,
     rooms: store.rooms.allIds,

--- a/client/src/Containers/Monitoring/MonitoringView.js
+++ b/client/src/Containers/Monitoring/MonitoringView.js
@@ -7,7 +7,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { NavItem, ToggleGroup, SimpleChat } from 'Components';
+import { NavItem, ToggleGroup, SimpleChat, CurrentMembers } from 'Components';
 import { updateMonitorSelections } from 'store/actions';
 import { usePopulatedRoom } from 'utils';
 import Chart from 'Containers/Stats/Chart';
@@ -59,6 +59,7 @@ function MonitoringView({
     VIEW: 'View',
     CHAT: 'Chat',
     THUMBNAIL: 'Thumbnail',
+    ATTENDANCE: 'Attendance',
     GRAPH: 'Graph',
     SIMPLE: 'Simple Chat',
     DETAILED: 'Detailed Chat',
@@ -118,7 +119,7 @@ function MonitoringView({
   const [selections, setSelections] = React.useState(
     _initializeSelections(userResources)
   );
-  const [viewType, setViewType] = React.useState(constants.CHAT);
+  const [viewType, setViewType] = React.useState(constants.ATTENDANCE);
   const [chatType, setChatType] = React.useState(constants.DETAILED);
   const savedState = React.useRef(selections);
 
@@ -262,6 +263,18 @@ function MonitoringView({
           />
         );
       }
+      case constants.ATTENDANCE: {
+        const data = queryStates[id].isSuccess ? queryStates[id].data : null;
+        return (
+          <CurrentMembers
+            members={data ? data.members : []}
+            currentMembers={data ? data.members.map((m) => m.user) : []}
+            activeMember={data ? data.currentMembers.map((m) => m._id) : []}
+            expanded
+            showTitle={false}
+          />
+        );
+      }
       default:
         return null;
     }
@@ -293,7 +306,12 @@ function MonitoringView({
         {viewOrSelect === constants.VIEW && (
           <Fragment>
             <ToggleGroup
-              buttons={[constants.CHAT, constants.THUMBNAIL, constants.GRAPH]}
+              buttons={[
+                constants.ATTENDANCE,
+                constants.CHAT,
+                constants.THUMBNAIL,
+                constants.GRAPH,
+              ]}
               value={viewType}
               onChange={setViewType}
             />

--- a/server/models/Course.js
+++ b/server/models/Course.js
@@ -18,7 +18,10 @@ const Course = new mongoose.Schema(
     members: [
       {
         user: { type: ObjectId, ref: 'User' },
-        role: { type: String, enum: ['facilitator', 'participant', 'guest'] },
+        role: {
+          type: String,
+          enum: ['facilitator', 'participant', 'guest', 'pending'],
+        },
         _id: false,
       },
     ],


### PR DESCRIPTION
Added new option to Monitoring that allows users to see who is currently in all the rooms being monitored. The "attendance" view shows all members of each room (reusing the "Currently in Room" component); members currently in the room are bolded.  As with other monitoring views, this new view is live -- it updates every 10 sec to show who is or isn't in the room. It also updates if a new member is added or a member is deleted.

This PR also includes a possible fix to allow imported members to appear without refreshing the screen, but still allow non-owning course facilitators to see all resources in a course (previously the latter fix had caused the former bug).