### PR TITLE
:bug: missing ntf name handled; fix for import resolution

### DIFF
--- a/client/src/Components/HOC/socketProvider.utils.js
+++ b/client/src/Components/HOC/socketProvider.utils.js
@@ -6,7 +6,9 @@ export default (notification, course, room, myResources) => {
   if (type === 'requestAccess') {
     const { username } = notification.fromUser;
     message = `${username} is requesting to join ${resource} ${
-      myResources[`${resource}s`][notification.resourceId].name
+      myResources[`${resource}s`][notification.resourceId]
+        ? myResources[`${resource}s`][notification.resourceId].name
+        : '<name not found>'
     }`;
   } else if (type === 'grantedAccess') {
     message = `your request to join ${resource} ${
@@ -15,7 +17,9 @@ export default (notification, course, room, myResources) => {
   } else if (type === 'newMember') {
     const { username } = notification.fromUser;
     message = `${username} joined ${resource} ${
-      myResources[`${resource}s`][notification.resourceId].name
+      myResources[`${resource}s`][notification.resourceId]
+        ? myResources[`${resource}s`][notification.resourceId].name
+        : '<name not found>'
     } `;
   } else if (type === 'invitation') {
     message = `you have been invited you to join ${resource} ${

--- a/client/src/Containers/Members/Members.js
+++ b/client/src/Containers/Members/Members.js
@@ -225,6 +225,7 @@ class Members extends PureComponent {
     });
 
     // handle validating whether username/email exists, whether they are consistent, and the resolution thereof
+    this.clearChoices(rowIndex);
     const userFromUsername = await validateExistingField(
       'username',
       d.username
@@ -382,6 +383,15 @@ class Members extends PureComponent {
     );
     this.setState((prevState) => ({
       rowConfig: [...prevState.rowConfig, { rowIndex, action }],
+    }));
+  };
+
+  // Remove any buttons from the previous validation
+  clearChoices = (rowIndex) => {
+    this.setState((prevState) => ({
+      rowConfig: prevState.rowConfig
+        ? prevState.rowConfig.filter((config) => config.rowIndex !== rowIndex)
+        : [],
     }));
   };
 


### PR DESCRIPTION
* Sometimes when a new person joins a group, the notification message cannot find the resource name. Instead of crashing, the notification will now show the name as "name not found". Cannot yet replicate the error, so haven't yet tracked down root cause of the problem.

* When importing, the resolution buttons (if a mismatch between existing username and email) now reset if the user fixes the mismatch.