### PR TITLE
Added course and template names to monitor table

### DIFF
--- a/client/src/Containers/Monitoring/SelectionTable.js
+++ b/client/src/Containers/Monitoring/SelectionTable.js
@@ -22,13 +22,23 @@ import classes from './selectionTable.css';
 export default function SelectionTable(props) {
   const { data, selections, onChange } = props;
   const tableData = data.map((datum) => {
-    const { _id, name, updatedAt, createdAt, currentMembers } = datum;
+    const {
+      _id,
+      name,
+      updatedAt,
+      createdAt,
+      currentMembers,
+      course,
+      activity,
+    } = datum;
     return {
       _id,
       name,
       updatedAt,
       createdAt,
       currentMembers: currentMembers && currentMembers.length,
+      courseName: course ? course.name : '',
+      templateName: activity ? activity.name : '',
     };
   });
 
@@ -91,6 +101,24 @@ export default function SelectionTable(props) {
           <th>
             <button
               type="button"
+              onClick={() => requestSort('courseName')}
+              className={classes[getClassNamesFor('courseName')]}
+            >
+              Course
+            </button>
+          </th>
+          <th>
+            <button
+              type="button"
+              onClick={() => requestSort('templateName')}
+              className={classes[getClassNamesFor('templateName')]}
+            >
+              Template
+            </button>
+          </th>
+          <th>
+            <button
+              type="button"
               onClick={() => requestSort('updatedAt')}
               className={classes[getClassNamesFor('updatedAt')]}
             >
@@ -122,6 +150,8 @@ export default function SelectionTable(props) {
             </td>
             <td>{item.name}</td>
             <td style={{ textAlign: 'center' }}>{item.currentMembers}</td>
+            <td>{item.courseName}</td>
+            <td>{item.templateName}</td>
             <td>{moment(item.updatedAt).format('LLL')}</td>
             <td>{moment(item.createdAt).format('LLL')}</td>
           </tr>

--- a/server/controllers/RoomController.js
+++ b/server/controllers/RoomController.js
@@ -68,6 +68,7 @@ module.exports = {
       .populate({ path: 'members.user', select: 'username' })
       .populate({ path: 'currentMembers', select: 'username' })
       .populate({ path: 'course', select: 'name' })
+      .populate({ path: 'activity', select: 'name' })
       .populate({
         path: 'tabs',
         populate: {


### PR DESCRIPTION
Adds two columns to the selection table in monitoring: course name (if any) for a room and the name of the template from which the room was generated (if any). As with other columns in this table, clicking on the column label sorts the table by that column.