### PR TITLE
Double room bug

### DIFF
--- a/server/cypress/integration/createRoom.js
+++ b/server/cypress/integration/createRoom.js
@@ -1,0 +1,52 @@
+// const capitalize = require('lodash/capitalize');
+const user = require('../fixtures/user');
+const room = require('../fixtures/room');
+const users = require('../../seeders/users');
+
+describe('shows corrects info after creating resources', function() {
+  before(function() {
+    cy.task('restoreAll').then(() => {
+      cy.login(user);
+    });
+  });
+
+  after(function() {
+    // cy.logout();
+  });
+
+  it('creates a new public ggb room & lists it in user resources', function() {
+    const { name } = room;
+
+    cy.getTestElement('tab')
+      .contains('Rooms')
+      .click();
+
+    cy.getTestElement(`create-room`).click();
+
+    cy.get(`input[name=name]`).type(name);
+    cy.get('button')
+      .contains('create')
+      .click();
+    cy.get('button')
+      .contains('next')
+      .click();
+    cy.get('button')
+      .contains('next')
+      .click();
+    cy.get('button')
+      .contains('next')
+      .click();
+    cy.get('button')
+      .contains('create')
+      .click();
+
+    cy.wait(1000);
+
+    cy.getTestElement(`content-box-${name}`).should('have.length', 1);
+
+    const originalRooms = users[0].rooms.length;
+    cy.getTestElement('box-list')
+      .children()
+      .should('have.length', originalRooms + 1);
+  });
+});

--- a/server/cypress/integration/createRoom.js
+++ b/server/cypress/integration/createRoom.js
@@ -4,17 +4,17 @@ const room = require('../fixtures/room');
 const users = require('../../seeders/users');
 
 describe('shows corrects info after creating resources', function() {
-  before(function() {
+  beforeEach(function() {
     cy.task('restoreAll').then(() => {
       cy.login(user);
     });
   });
 
-  after(function() {
-    // cy.logout();
+  afterEach(function() {
+    cy.logout();
   });
 
-  it('creates a new public ggb room & lists it in user resources', function() {
+  it('creates a new public ggb room & lists it once in user resources', function() {
     const { name } = room;
 
     cy.getTestElement('tab')
@@ -43,6 +43,40 @@ describe('shows corrects info after creating resources', function() {
     cy.wait(1000);
 
     cy.getTestElement(`content-box-${name}`).should('have.length', 1);
+
+    const originalRooms = users[0].rooms.length;
+    cy.getTestElement('box-list')
+      .children()
+      .should('have.length', originalRooms + 1);
+  });
+
+  it('creates a new public ggb room & exactly ONE new resources is added to list', function() {
+    const { name } = room;
+
+    cy.getTestElement('tab')
+      .contains('Rooms')
+      .click();
+
+    cy.getTestElement(`create-room`).click();
+
+    cy.get(`input[name=name]`).type(name);
+    cy.get('button')
+      .contains('create')
+      .click();
+    cy.get('button')
+      .contains('next')
+      .click();
+    cy.get('button')
+      .contains('next')
+      .click();
+    cy.get('button')
+      .contains('next')
+      .click();
+    cy.get('button')
+      .contains('create')
+      .click();
+
+    cy.wait(1000);
 
     const originalRooms = users[0].rooms.length;
     cy.getTestElement('box-list')

--- a/server/models/Room.js
+++ b/server/models/Room.js
@@ -117,7 +117,7 @@ Room.post('save', function(doc, next) {
         // const query = { $addToSet: { rooms: this._id } };
         // @TODO use notification schema
         let notification;
-        if (member.user !== this.creator) {
+        if (member.user.toString() !== this.creator.toString()) {
           notification = {
             notificationType: 'assignedNewRoom',
             resourceType: 'room',


### PR DESCRIPTION
This PR fixes the bug whereby when a user creates a room it appears twice in the resource list. At the same time, the user gets a notification about the room as if they were invited raters than they had created it. 

This PR includes the fix as well as a Cypress integration test suite (which was written first, of course).