### PR TITLE
Development

### DIFF
--- a/client/src/Containers/Workspace/DesmosActivity.js
+++ b/client/src/Containers/Workspace/DesmosActivity.js
@@ -213,11 +213,14 @@ const DesmosActivity = (props) => {
 
     if (tab.currentStateBase64 && tab.currentStateBase64 !== '{}') {
       // existing event data on tab
-      const { currentStateBase64, startingPointBase64 } = tab;
+      const { currentStateBase64, startingPointBase64, desmosLink } = tab;
       const savedData = JSON.parse(currentStateBase64);
       playerOptions.responseData = savedData;
-      // in case we have data but no config, resave the configuration
-      if (!startingPointBase64 || startingPointBase64 === '{}') {
+      // in case we have data but no config, resave the configuration from link
+      if (
+        !startingPointBase64 ||
+        (startingPointBase64 === '{}' && desmosLink)
+      ) {
         putState(config);
       }
     } else {

--- a/client/src/Containers/Workspace/DesmosActivity.js
+++ b/client/src/Containers/Workspace/DesmosActivity.js
@@ -213,9 +213,13 @@ const DesmosActivity = (props) => {
 
     if (tab.currentStateBase64 && tab.currentStateBase64 !== '{}') {
       // existing event data on tab
-      const { currentStateBase64 } = tab;
+      const { currentStateBase64, startingPointBase64 } = tab;
       const savedData = JSON.parse(currentStateBase64);
       playerOptions.responseData = savedData;
+      // in case we have data but no config, resave the configuration
+      if (!startingPointBase64 || startingPointBase64 === '{}') {
+        putState(config);
+      }
     } else {
       // first load or no events, save configuration
       putState(config);

--- a/client/src/Containers/Workspace/Tools/DesActivityHelpers.js
+++ b/client/src/Containers/Workspace/Tools/DesActivityHelpers.js
@@ -8,9 +8,10 @@ export const fetchConfigData = async (tab) => {
   const configData = {};
   // Room condition
   if (tab.room) {
-    // if we have a starting config and saved data, return the config
+    // if we have a valid starting config and saved data, return the config
     if (
       tab.startingPointBase64 &&
+      tab.startingPointBase64 !== '{}' &&
       // Check to see if there is any activity
       tab.currentStateBase64
     ) {


### PR DESCRIPTION
Somehow rooms were created that had an invalid Desmos Activity configuration (on the tab as startingpointbase64). THis would cause the DesHelper to fetch and return the empty configuration and the room would fail to load. 

This PR also includes a check that if a room config is false or invalid ('{}') it will resave the newly fetched configuration if the tab has a desmosLink.

It's not sure how the bad startingtpoint config occurred however. 