### PR TITLE
Import headings are now case insensitive

### DIFF
--- a/client/src/Components/Importer/Importer.js
+++ b/client/src/Components/Importer/Importer.js
@@ -326,6 +326,19 @@ export default function Importer(props) {
     onImport(userObjects);
   };
 
+  const transformHeader = (header) => {
+    switch (header.toLowerCase()) {
+      case 'isgmail':
+        return 'isGmail';
+      case 'firstname':
+        return 'firstName';
+      case 'lastname':
+        return 'lastName';
+      default:
+        return header.toLowerCase();
+    }
+  };
+
   const importModal = () => {
     return (
       <ImportModal
@@ -390,7 +403,11 @@ export default function Importer(props) {
         ref={buttonRef}
         onFileLoad={handleOnFileLoad}
         onError={handleOnError}
-        config={{ header: true, skipEmptyLines: true }}
+        config={{
+          header: true,
+          skipEmptyLines: true,
+          transformHeader,
+        }}
         noProgressBar
         noDrag
       >


### PR DESCRIPTION
When importing, the column headings in the CSV do not depend on case any longer. For example, in the CSV file, the header for the column of first names may be written as Firstname, firstname, FIRSTNAME, etc., and the data will be imported to the firstName field correctly.