### PR TITLE
:clock130: Use server time jic client time wrong

### DIFF
--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -52,6 +52,7 @@ const Event = new mongoose.Schema({
 Event.pre('save', async function() {
   // tabs[this.tabIndex].events.push(this._id)
   try {
+    this.timestamp = new Date().getTime();
     await Tab.findByIdAndUpdate(this.tab, { $addToSet: { events: this._id } });
   } catch (err) {
     console.error(err);

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -44,6 +44,7 @@ const Message = new mongoose.Schema({
 // Add this message to the room's chat
 Message.pre('save', async function() {
   if (this.isNew) {
+    this.timestamp = new Date().getTime();
     // @TODO CHANGIN controlledBY HERE IS TERRRRIBLLE!!!!! THIS SHOULD ALL BE DONE SOMEWHERE ELSE WHERE ITS LESS OF A SIDE EFFECT
     if (this.messageType === 'TOOK_CONTROL') {
       try {


### PR DESCRIPTION
This PR fixes a looooong-standing bug whereby messages and events receive the wrong timestamp if a user's clock is incorrect. As a result, the replayer would present events and messages in an order different than how they actually occurred.