### PR TITLE
Prevent spamming of RequestControl button

### DIFF
--- a/client/src/Components/UI/Button/Button.js
+++ b/client/src/Components/UI/Button/Button.js
@@ -7,7 +7,7 @@ const Button = (props) => {
   // let styles = [classes.Button]
   let styles = classes[theme];
   if (disabled) {
-    styles = classes.Disabled;
+    styles = [classes[theme], classes.Disabled].join(' ');
   }
   return (
     // eslint-disable-next-line react/button-has-type

--- a/client/src/Containers/Workspace/Tools/Tools.js
+++ b/client/src/Containers/Workspace/Tools/Tools.js
@@ -20,15 +20,52 @@ const Tools = ({
   inAdminMode,
   createActivity,
 }) => {
-  let controlText;
-  if (!replayer) {
-    controlText = 'Request Control';
-    if (inControl === 'ME') {
-      controlText = 'Release Control';
-    } else if (inControl === 'NONE') {
-      controlText = 'Take Control';
+  // controlText is what gets displayed in the control-related button (either Take Control, Release Control, Request Control,
+  // or Requested).
+  const [controlText, setControlText] = React.useState('Take Control'); // Needs a value, but doesn't matter as it gets set in the useEffect
+  const [controlDisabled, setControlDisabled] = React.useState(false);
+  const timer = React.useRef();
+
+  // Prevent spamming of the RequestControl button. When that's clicked, disable the button for one minute
+  // and change the text to Requested.
+  const checkControl = () => {
+    toggleControl();
+    if (controlText === 'Request Control') {
+      setControlDisabled(true);
+      setControlText('Requested');
+      timer.current = setTimeout(() => {
+        setControlDisabled(false);
+        setControlText(determineControlText(inControl));
+      }, 60000);
     }
-  }
+  };
+
+  const determineControlText = (controller) => {
+    switch (controller) {
+      case 'ME':
+        return 'Release Control';
+      case 'NONE':
+        return 'Take Control';
+      default:
+        return 'Request Control';
+    }
+  };
+
+  // When the person in control changes, we want to reset the button (i.e., undisable) and adjust the text of the
+  // button as appropriate.
+  React.useEffect(() => {
+    resetRequested();
+    if (!replayer) setControlText(determineControlText(inControl));
+    return () => {
+      // clear the timer before unmounting
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [replayer, inControl]);
+
+  const resetRequested = () => {
+    if (timer.current) clearTimeout(timer.current);
+    setControlDisabled(false);
+  };
 
   return (
     <div className={classes.Container}>
@@ -102,10 +139,9 @@ const Tools = ({
             {!replayer && !inAdminMode ? (
               <Button
                 theme="xs"
-                data-testid={
-                  inControl === 'ME' ? 'release-control' : 'take-control'
-                }
-                click={toggleControl}
+                data-testid="control-button"
+                disabled={controlDisabled}
+                click={checkControl}
               >
                 {controlText}
               </Button>

--- a/server/cypress/integration/workspace.js
+++ b/server/cypress/integration/workspace.js
@@ -99,8 +99,8 @@ describe('Workspace/replayer', function() {
   });
   it('prevents tool selection without taking control', function() {
     checkAwareness('jl_picard joined room 1');
-    cy.getTestElement('take-control').click();
-    cy.getTestElement('release-control').click();
+    cy.getTestElement('control-button').click(); // take control
+    cy.getTestElement('control-button').click(); // release control
     cy.get(':nth-child(5) > .toolbar_button > .gwt-Image').click();
     cy.getTestElement('control-warning').should('be.visible');
     cy.getTestElement('cancel').click();
@@ -109,7 +109,7 @@ describe('Workspace/replayer', function() {
       .should('have.length', 3); // no longer emitting event for selecting move tool after taking control
   });
   it('allows tool selection after taking control', function() {
-    cy.getTestElement('take-control').click();
+    cy.getTestElement('control-button').click(); // take control
 
     checkAwareness('jl_picard took control');
 


### PR DESCRIPTION
Requested feature: When a user requests control, they may not do so again for one minute. If control changes during that minute, the button resets as appropriate.