### PR TITLE
Check for admin mode on leaving room

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -194,7 +194,7 @@ class Workspace extends Component {
     const { populatedRoom, connectUpdatedRoom, user } = this.props;
     const { myColor, currentMembers, cancelSnapshots } = this.state;
     // don't generate a LEAVE message if the user is an admin
-    if (!user.isAdmin) {
+    if (!user.inAdminMode) {
       socket.emit('LEAVE_ROOM', populatedRoom._id, myColor);
       // Below updates the Redux store, removing the current user from the list of people in the room (currentMembers).
       // However, this might not be needed as the socket updates the DB with the current members. The next time this info is needed, in


### PR DESCRIPTION
Fixes bug whereby an admin leaving a room generated "VMTBot: undefined left the room". That no longer happens.