### PR TITLE
:tada: VMT automatically reloads if a new deployment

### DIFF
--- a/client/config/webpack.config.prod.js
+++ b/client/config/webpack.config.prod.js
@@ -328,6 +328,8 @@ module.exports = {
       navigateFallbackWhitelist: [/^(?!\/__).*/],
       // Don't precache sourcemaps (they're large) and build asset manifest:
       globIgnores: ['*.map', 'asset-manifest.json'],
+      skipWaiting: true,
+      clientsClaim: true,
     }),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical

--- a/client/config/webpack.config.prod.js
+++ b/client/config/webpack.config.prod.js
@@ -328,6 +328,8 @@ module.exports = {
       navigateFallbackWhitelist: [/^(?!\/__).*/],
       // Don't precache sourcemaps (they're large) and build asset manifest:
       globIgnores: ['*.map', 'asset-manifest.json'],
+      // When we deploy a new version, we want to activate the new service worker immediately, not requiring users to actively refresh the previously
+      // cached service worker (previous deployment). See https://developers.google.com/web/tools/workbox/guides/generate-complete-sw
       skipWaiting: true,
       clientsClaim: true,
     }),


### PR DESCRIPTION
When we deploy a new version of VMT, users' browsers will automatically load the new version within a few seconds (i.e., no browser refresh needed).