### PR TITLE
:tada: default passwords now handled on server side

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -16,5 +16,3 @@ REACT_APP_PYRET_MODE='yes'
 REACT_APP_PYRET_URL='https://pyret-horizon.herokuapp.com/editor'
 
 NODE_PATH=src
-# a default password for the client to use for proxy accounts
-REACT_APP_VMT_LOGIN_DEFAULT='s0meDef@ultP@ssw0rd'

--- a/client/src/Layout/ClassCode/ClassCode.js
+++ b/client/src/Layout/ClassCode/ClassCode.js
@@ -109,7 +109,7 @@ function ClassCode(props) {
         email: memberToConf.user.email || '',
         firstName: memberToConf.user.firstName,
         lastName: memberToConf.user.lastName,
-        password: process.env.REACT_APP_VMT_LOGIN_DEFAULT,
+        // password: process.env.REACT_APP_VMT_LOGIN_DEFAULT,
         rooms: memberToConf.user.rooms,
         courses: memberToConf.user.courses,
         username: memberToConf.user.username,
@@ -117,11 +117,13 @@ function ClassCode(props) {
       };
 
       // console.log('signing up user: ', userToConvert);
-      signup(userToConvert);
+      signup(userToConvert, true); // 'true' indicates that the user will not be required to login with a password.
     } else if (!memberToConf.user.isGmail) {
       login(
         memberToConf.user.username,
-        process.env.REACT_APP_VMT_LOGIN_DEFAULT
+        'dummy',
+        true // flag indicating that the user may login without a password.
+        // process.env.REACT_APP_VMT_LOGIN_DEFAULT
       );
     } else {
       history.push('/login');

--- a/client/src/store/actions/user.js
+++ b/client/src/store/actions/user.js
@@ -103,14 +103,21 @@ export const clearNotification = (ntfId) => {
   };
 };
 
-export const signup = (body) => {
+/**
+ * Signup and Login now accept a 'special' flag. This flag
+ * tells the server that the user is being allowed to signup or login without
+ * a password. The server will then create the user (signup) or connect with
+ * the default password specified in the server/.env file.
+ */
+export const signup = (body, special = false) => {
   // room is optional -- if we're siging up someone in a temp room
+  const signupFn = special ? AUTH.signupSpecial : AUTH.signup;
   return (dispatch) => {
     // if (room) {
     //   // dispatch(updateRoomMembers(room, {user:{username: body.username, _id: body._id}, role: 'facilitator'}))
     // }
     dispatch(loading.start());
-    AUTH.signup(body)
+    signupFn(body)
       .then((res) => {
         if (res.data.errorMessage) {
           return dispatch(loading.fail(res.data.errorMessage));
@@ -157,10 +164,11 @@ export const signupMultiple = (bodies) => {
   };
 };
 
-export const login = (username, password) => {
+export const login = (username, password, special = false) => {
+  const loginFn = special ? AUTH.loginSpecial : AUTH.login;
   return (dispatch) => {
     dispatch(loading.start());
-    AUTH.login(username, password)
+    loginFn(username, password)
       .then((res) => {
         if (res.data.errorMessage) {
           return dispatch(loading.fail(res.data.errorMessage));

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -9,6 +9,12 @@ export default {
   login: (username, password) => {
     return axios.post('/auth/login', { username, password });
   },
+  signupSpecial: (user) => {
+    return axios.post('/auth/signupSpecial', user);
+  },
+  loginSpecial: (username) => {
+    return axios.post('/auth/loginSpecial', { username });
+  },
   googleLogin: (username, password) => {
     return axios.get('/auth/googleAuth', { username, password });
   },

--- a/server/.env.example
+++ b/server/.env.example
@@ -52,3 +52,5 @@ ENC_JWT_ISSUER_ID_PROD=<JWT ID enc dev>
 
 # used if you want to monitor socket race conditons externally
 #BAD_DATA_URL=
+
+VMT_LOGIN_DEFAULT=<default password>

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -41,7 +41,21 @@ if (process.env.NODE_ENV === 'test') {
   secret = process.env.MT_USER_JWT_SECRET;
 }
 
+const addDefaultPassword = (req) => ({
+  ...req,
+  body: { ...req.body, password: process.env.VMT_LOGIN_DEFAULT },
+});
+
+// login by using the default password (used in client/ClassCode.js)
+router.post('/loginSpecial', async (req, res) => {
+  return login(addDefaultPassword(req), res);
+});
+
 router.post('/login', async (req, res) => {
+  return login(req, res);
+});
+
+const login = async (req, res) => {
   try {
     const { message, accessToken, refreshToken } = await ssoService.login(
       req.body
@@ -80,9 +94,19 @@ router.post('/login', async (req, res) => {
   } catch (err) {
     return errors.sendError.InternalError(null, res);
   }
+};
+
+// signing up by using the default password (used in client/ClassCode.js).
+// i.e., for users created by the Import facility
+router.post('/signupSpecial', async (req, res) => {
+  return signup(addDefaultPassword(req), res);
 });
 
 router.post('/signup', async (req, res) => {
+  return signup(req, res);
+});
+
+const signup = async (req, res) => {
   try {
     const { message, accessToken, refreshToken } = await ssoService.signup(
       req.body
@@ -135,7 +159,7 @@ router.post('/signup', async (req, res) => {
     console.log('err signup', err);
     return errors.sendError.InternalError(null, res);
   }
-});
+};
 
 router.post('/logout/:userId', (req, res) => {
   User.findByIdAndUpdate(req.params.userId, { socketId: null })


### PR DESCRIPTION
In an effort to reduce the need for Client environment variables, which is needed as we moved to Docker, this PR changes the handling of 'default password' (used when students login without a password via a course code) from client-side code to server-side code.  Users should not see any difference in system behavior.