### PR TITLE
:tada: new approach to stop clicks if not in control

### DIFF
--- a/client/src/Containers/Workspace/DesmosActivity.js
+++ b/client/src/Containers/Workspace/DesmosActivity.js
@@ -324,7 +324,8 @@ const DesmosActivity = (props) => {
   function _checkForControl(event) {
     // check if user is not in control and intercept event
     if (!_hasControl()) {
-      event.preventDefault();
+      // event.preventDefault();
+      // event.stopPropagation();
       setShowControlWarning(true);
       // return;
     }
@@ -343,7 +344,6 @@ const DesmosActivity = (props) => {
   return (
     <Fragment>
       <Modal show={!!showConfigError} closeModal={handleOnErrorClick}>
-        {' '}
         {showConfigError}
       </Modal>
       <ControlWarningModal
@@ -361,23 +361,7 @@ const DesmosActivity = (props) => {
         }}
         inAdminMode={user ? user.inAdminMode : false}
       />
-      {/* @TODO None of the needed props are received right now
-      <CheckboxModal
-        show={showRefWarning}
-        infoMessage={refWarningMsg}
-        closeModal={closeRefWarning}
-        isChecked={doPreventFutureRefWarnings}
-        checkboxDataId="ref-warning"
-        onSelect={togglePreventRefWarning}
-      /> */}
-      <div
-        id="activityNavigation"
-        className={classes.ActivityNav}
-        onClickCapture={_checkForControl}
-        style={{
-          pointerEvents: !_hasControl() ? 'none' : 'auto',
-        }}
-      >
+      <div id="activityNavigation" className={classes.ActivityNav}>
         {_hasControl() && backBtn && (
           <Button theme="Small" id="nav-left" click={() => navigateBy(-1)}>
             Prev
@@ -399,23 +383,19 @@ const DesmosActivity = (props) => {
           </Button>
         )}
       </div>
-      <div
-        className={classes.Activity}
-        onClickCapture={_checkForControl}
-        id="calculatorParent"
-        style={{
-          height: '890px', // @TODO this needs to be adjusted based on the Player instance.
-        }}
-      >
-        <div
-          className={classes.Graph}
-          id="calculator"
-          ref={calculatorRef}
-          style={{
-            overflow: 'auto',
-            pointerEvents: !_hasControl() ? 'none' : 'auto',
-          }}
-        />
+      <div className={classes.Activity}>
+        <div className={classes.Graph} id="calculator" ref={calculatorRef} />
+        {!_hasControl() && (
+          <div
+            className={classes.Control}
+            onClickCapture={_checkForControl}
+            onClick={_checkForControl}
+            onKeyPress={_checkForControl}
+            tabIndex="-1"
+            id="calculatorParent"
+            role="button"
+          />
+        )}
       </div>
     </Fragment>
   );

--- a/client/src/Containers/Workspace/DesmosActivity.js
+++ b/client/src/Containers/Workspace/DesmosActivity.js
@@ -321,7 +321,7 @@ const DesmosActivity = (props) => {
   }
 
   // @TODO this could be selectively handled depending what div is clicked
-  function _checkForControl(event) {
+  function _checkForControl() {
     // check if user is not in control and intercept event
     if (!_hasControl()) {
       // event.preventDefault();
@@ -330,6 +330,27 @@ const DesmosActivity = (props) => {
       // return;
     }
   }
+
+  const _calculatorWidth = () => {
+    const defaultWidth = calculatorRef.current
+      ? calculatorRef.current.clientWidth - 16
+      : '100%';
+    /**
+     * The class dcg-student-screen is documented in https://github.com/desmosinc/21pstem-desmos-api-builds/tree/march-2022-rebase/css#screen-1.
+     * Unfortunately, there are potentially three divs with that class -- before, current, and after. 'Current' is always not hidden. Thus, there
+     * are three ways to get the correct element: has the current-screen class, the dcg-student-screen that isn't hidden,or the dcg-student-screen marked
+     * with the current-screen class. We use the third approach because it uses a documented class and, right now, reliably identifies what we want:
+     * the current screen (rather than 'the screen not hidden,' which is semantically indirect).
+     */
+    const elements = document.querySelectorAll(
+      // '.current-screen'
+      // '.dcg-student-screen[aria-hidden=false]'
+      '.dcg-student-screen.current-screen'
+    );
+    if (elements.length === 0) return defaultWidth;
+    const currentScreen = elements[0];
+    return currentScreen.clientWidth || defaultWidth;
+  };
 
   const {
     inControl,
@@ -388,12 +409,13 @@ const DesmosActivity = (props) => {
         {!_hasControl() && (
           <div
             className={classes.Control}
-            onClickCapture={_checkForControl}
             onClick={_checkForControl}
             onKeyPress={_checkForControl}
             tabIndex="-1"
-            id="calculatorParent"
             role="button"
+            style={{
+              width: _calculatorWidth() || '100%',
+            }}
           />
         )}
       </div>

--- a/client/src/Containers/Workspace/graph.css
+++ b/client/src/Containers/Workspace/graph.css
@@ -5,15 +5,20 @@
   red: red;
 }
 
+.Activity {
+
+}
+
 .Graph {
   height: 100%;
   width: 100%;
-  /* z-index: 991; */
 }
 
-.Activity {
-  /* position: absolute; */
-  /* z-index: 990; */
+.Control {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  /* background-color: rgba(0,0,0,0.5) */
 }
 
 .ControlWarning {

--- a/client/src/Containers/Workspace/graph.css
+++ b/client/src/Containers/Workspace/graph.css
@@ -16,7 +16,7 @@
 
 .Control {
   height: 100%;
-  width: 100%;
+  /* width: 100%; */ /* We calculate the width based on the Graph element to account for vertical scrollbar */
   position: absolute;
   /* background-color: rgba(0,0,0,0.5) */
 }


### PR DESCRIPTION
This PR implements a new approach to preventing students from interacting with a Desmos Activity when they are not in control. This new approach captures ALL clicks, even on 'Try it', 'Check My Work', 'Reset', and animation play buttons that had previously allowed students to click on them.

We also allow for a possible scrollbar -- so that the student can scroll the DesmosActivity (vertically) without having control.