### PR TITLE
Resource Sort fixes

### DIFF
--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -275,6 +275,7 @@ const SortUI = ({ keys, sortFn, sortConfig }) => {
             value: key.property,
             label: key.name,
           }))}
+          isSearchable={false}
         />
         <span onClick={() => sortFn(sortConfig.key)}>
           {sortConfig.direction === 'descending' ? downArrow : upArrow}

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -25,7 +25,7 @@ export const useSortableData = (items, config = null) => {
     let sortableItems = [...items];
     if (sortConfig !== null) {
       sortableItems.sort((a, b) => {
-        if (a[sortConfig.key] < b[sortConfig.key]) {
+        if (a[sortConfig.key].toLowerCase() < b[sortConfig.key].toLowerCase()) {
           return sortConfig.direction === 'ascending' ? -1 : 1;
         }
         if (a[sortConfig.key] > b[sortConfig.key]) {


### PR DESCRIPTION
This PR implements the following fixes to sorting resources:

1. Alphabetized sorting is no longer case-sensitive
2. The Select options are no longer searchable