### PR TITLE
:tada: Template editor gets smaller navbar to accommodate preview

### DIFF
--- a/client/src/Components/Navigation/Navbar.js
+++ b/client/src/Components/Navigation/Navbar.js
@@ -22,6 +22,13 @@ const Navbar = ({ user, location, toggleAdmin }) => {
     styles = classes.Fixed;
   }
 
+  if (
+    location.pathname.includes('workspace') &&
+    location.pathname.includes('activity')
+  ) {
+    styles = classes.EditorNavContainer;
+  }
+
   const aboutList = [
     { name: 'About', link: '/about' },
     { name: 'Instructions', link: '/instructions' },

--- a/client/src/Components/Navigation/dropdownNavItem.css
+++ b/client/src/Components/Navigation/dropdownNavItem.css
@@ -16,7 +16,7 @@
 .DropdownContent {
   display: none;
   position: absolute;
-  top: 56px;
+  top: 90%; /* for different navbar heights, dropdown will appear at the bottom, slightly overlapping */
   left: 0;
   right: 0;
   /* border: 1px solid red; */

--- a/client/src/Components/Navigation/navbar.css
+++ b/client/src/Components/Navigation/navbar.css
@@ -24,6 +24,12 @@
   height: navbarHeight;
 }
 
+.EditorNavContainer {
+  composes: NavContainer;
+  width: 95%;
+  height: calc(navbarHeight * .5);
+}
+
 .WorkspaceNav {
   composes: NavContainer;
   box-shadow: none;


### PR DESCRIPTION
This PR addresses a bug whereby parts of the Desmos Activity editor preview was hidden behind the VMT navigation bar. To accommodate the editor preview, which takes up the entire screen, the VMT navigation bar has been made smaller (shorter and slightly narrower). 

This change to the navigation bar appears any time the user edits a template. At some time in the future, it should be changed to appear only if a Desmos Activity is being edited.