### PR TITLE
Tab Types displayed throughout VMT, Side Panel css changes

### DIFF
--- a/client/src/Components/ToolTip/toolTip.css
+++ b/client/src/Components/ToolTip/toolTip.css
@@ -23,6 +23,7 @@
   white-space: no-wrap;
   text-overflow: ellipsis; /* <-- this is not working */
   margin-left: -22px;
+  text-transform: capitalize;
 }
 
 .ToolTipText::after {

--- a/client/src/Components/UI/ContentBox/ContentBox.js
+++ b/client/src/Components/UI/ContentBox/ContentBox.js
@@ -6,11 +6,26 @@ import Icons from './Icons/Icons';
 import Aux from '../../HOC/Auxil';
 import Expand from './expand';
 import Notification from '../../Notification/Notification';
+import getResourceTabTypes from 'utils/getResourceTabTypes';
 
 class ContentBox extends PureComponent {
   state = {
     expanded: false,
+    typeKeyword: 'Tab Type',
+    tabTypes: '',
   };
+
+  componentDidMount() {
+    const { roomType } = this.props;
+
+    if (roomType) {
+      const { tabTypes, isPlural } = getResourceTabTypes(
+        roomType
+      );
+      const tempTypeKeyword = isPlural ? 'Tab Types' : 'Tab Type';
+      this.setState({ typeKeyword: tempTypeKeyword, tabTypes });
+    }
+  }
 
   toggleExpand = (event) => {
     event.preventDefault();
@@ -30,7 +45,7 @@ class ContentBox extends PureComponent {
       locked,
       details,
     } = this.props;
-    const { expanded } = this.state;
+    const { expanded, tabTypes, typeKeyword } = this.state;
     const notificationElements =
       notifications > 0 ? (
         <Notification count={notifications} data-testid="content-box-ntf" />
@@ -102,6 +117,11 @@ class ContentBox extends PureComponent {
                   ) : null}
                   {details.description ? (
                     <div>Description: {details.description}</div>
+                  ) : null}
+                  {tabTypes && tabTypes.length ? (
+                    <div className={classes.TabTypes}>
+                      {typeKeyword}: {tabTypes}
+                    </div>
                   ) : null}
                 </div>
               ) : null}

--- a/client/src/Components/UI/ContentBox/Icons/Icons.js
+++ b/client/src/Components/UI/ContentBox/Icons/Icons.js
@@ -7,6 +7,7 @@ import pyretIcon from './pyretlogo.png';
 import bothIcon from './desmosandgeogebra.png';
 import ToolTip from '../../../ToolTip/ToolTip';
 import classes from './icons.css';
+import getResourceTabTypes from 'utils/getResourceTabTypes';
 
 const Icons = ({ lock, listType, roomType, image }) => {
   let lockIcon;
@@ -31,8 +32,10 @@ const Icons = ({ lock, listType, roomType, image }) => {
     );
   }
 
+  const { tabTypes: toolTipText } = getResourceTabTypes(roomType);
+
   const desImageAndToolTip = (
-    <ToolTip text="Desmos" delay={600}>
+    <ToolTip text={toolTipText} delay={600}>
       <div className={classes.Icon}>
         <img width={25} src={dsmIcon} alt="dsm" />
       </div>
@@ -40,7 +43,7 @@ const Icons = ({ lock, listType, roomType, image }) => {
   );
 
   const desActImageAndToolTip = (
-    <ToolTip text="DesmosActivity" delay={600}>
+    <ToolTip text={toolTipText} delay={600}>
       <div className={classes.Icon}>
         <img width={25} src={dsmActIcon} alt="dsm" />
       </div>
@@ -48,7 +51,7 @@ const Icons = ({ lock, listType, roomType, image }) => {
   );
 
   const ggbImageAndToolTip = (
-    <ToolTip text="GeoGebra" delay={600}>
+    <ToolTip text={toolTipText} delay={600}>
       <div className={classes.Icon}>
         <img width={28} src={ggbIcon} alt="ggb" />
       </div>
@@ -56,7 +59,7 @@ const Icons = ({ lock, listType, roomType, image }) => {
   );
 
   const pyretImageAndToolTip = (
-    <ToolTip text="Pyret" delay={600}>
+    <ToolTip text={toolTipText} delay={600}>
       <div className={classes.Icon}>
         <img width={28} src={pyretIcon} alt="pyret" />
       </div>
@@ -67,6 +70,7 @@ const Icons = ({ lock, listType, roomType, image }) => {
     let ggb = false;
     let act = false;
     let pyrt = false;
+
     roomType.forEach((rmType) => {
       if (rmType === 'desmos') des = true;
       else if (rmType === 'desmosActivity') act = true;
@@ -75,7 +79,7 @@ const Icons = ({ lock, listType, roomType, image }) => {
     });
     if (ggb && des) {
       roomTypeIcon = (
-        <ToolTip text="GeoGebra/Desmos" delay={600}>
+        <ToolTip text={toolTipText} delay={600}>
           <div className={classes.Icon}>
             <img width={25} src={bothIcon} alt="ggb" />
           </div>

--- a/client/src/Components/UI/ContentBox/contentBox.css
+++ b/client/src/Components/UI/ContentBox/contentBox.css
@@ -112,3 +112,7 @@
   position: relative;
   top: 3px;
 }
+
+.TabTypes {
+  text-transform: capitalize;
+}

--- a/client/src/Containers/Activity.js
+++ b/client/src/Containers/Activity.js
@@ -27,6 +27,7 @@ import {
 import { populateResource } from '../store/reducers';
 import Access from './Access';
 import TemplatePreview from './Monitoring/TemplatePreview';
+import getResourceTabTypes from 'utils/getResourceTabTypes';
 
 class Activity extends Component {
   constructor(props) {
@@ -47,19 +48,18 @@ class Activity extends Component {
       privacySetting: activity ? activity.privacySetting : null,
       canAccess: false,
       roomType: '',
+      isPlural: false,
     };
   }
 
   componentDidMount() {
     const { activity, connectGetCurrentActivity, match } = this.props;
 
-    const newRoomType = activity.tabs
-      .reduce((acc, curr) => {
-        return acc.includes(curr.tabType) ? acc : acc.concat(curr.tabType);
-      }, [])
-      .join(' / ');
-
-    this.setState({ roomType: newRoomType });
+    if (activity && activity.tabs) {
+      const tabsInRoom = activity.tabs.map((tab) => tab.tabType);
+      const { tabTypes, isPlural } = getResourceTabTypes(tabsInRoom);
+      this.setState({ roomType: tabTypes, isPlural });
+    }
 
     if (!activity) {
       connectGetCurrentActivity(match.params.activity_id); // WHY ARE WE DOING THIS??
@@ -178,11 +178,12 @@ class Activity extends Component {
       trashing,
       canAccess,
       roomType,
+      isPlural,
     } = this.state;
     if (activity && canAccess) {
       const { resource } = match.params;
 
-      const keyword = roomType.includes('/') ? 'types' : 'type';
+      const keyword = isPlural ? 'types' : 'type';
       const additionalDetails = {
         [keyword]: roomType,
         privacy: (

--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -38,6 +38,7 @@ import Stats from './Stats/Stats';
 // import withPopulatedRoom from './Data/withPopulatedRoom';
 import Access from './Access';
 import RoomPreview from './Monitoring/RoomPreview';
+import getResourceTabTypes from 'utils/getResourceTabTypes';
 
 class Room extends Component {
   initialTabs = [{ name: 'Details' }, { name: 'Members' }];
@@ -66,6 +67,7 @@ class Room extends Component {
       trashing: false,
       isAdmin: false,
       roomType: '',
+      isPlural: false,
     };
   }
 
@@ -115,13 +117,11 @@ class Room extends Component {
       this.fetchRoom();
     }
 
-    const newRoomType = room.tabs
-      .reduce((acc, curr) => {
-        return acc.includes(curr.tabType) ? acc : acc.concat(curr.tabType);
-      }, [])
-      .join(' / ');
-
-    this.setState({ roomType: newRoomType });
+    if (room && room.tabs) {
+      const tabTypes = room.tabs.map((tab) => tab.tabType);
+      const { tabTypes: roomType, isPlural } = getResourceTabTypes(tabTypes);
+      this.setState({ roomType, isPlural });
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -340,6 +340,7 @@ class Room extends Component {
       name,
       trashing,
       roomType,
+      isPlural,
     } = this.state;
     if (room && room.tabs && !guestMode) {
       // ESLINT thinks this is unnecessary but we use the keys directly in the dom and we want them to have spaces
@@ -348,7 +349,7 @@ class Room extends Component {
       // make component which accepts each tab & makes the appropriate icon
 
       const { updateFail, updateKeys } = loading;
-      const keyword = roomType.includes('/') ? 'types' : 'type';
+      const keyword = isPlural ? 'types' : 'type';
       const additionalDetails = {
         [dueDateText]: (
           <Error error={updateFail && updateKeys.indexOf('dueDate') > -1}>

--- a/client/src/Layout/Dashboard/SidePanel/sidePanel.css
+++ b/client/src/Layout/Dashboard/SidePanel/sidePanel.css
@@ -34,6 +34,7 @@
   font-size: 26px;
   font-weight: 600;
   margin: 10px 0 5px 0;
+  text-align: center;
 }
 
 .spSecondary {
@@ -41,10 +42,10 @@
   color: #666;
   margin-bottom: 15px;
   font-weight: 300;
+  text-align: center;
 }
 
-.spAdditional {
-  padding: 15px 0;
+.spAdditional {  
   border-top: 1px solid lightBorder;
   border-bottom: 1px solid lightBorder;
 }
@@ -116,6 +117,7 @@
   box-shadow: lightestShadow;
   border: 1px solid #ddd;
   background: white;
+  width: 50%;
 }
 
 .Details {
@@ -128,7 +130,7 @@
 
 .KeyContainer {
   margin: 10px 0;
-  padding: 0 2px;
+  padding: 10px 2px;
 }
 
 .KeyName {
@@ -142,6 +144,9 @@
   font-weight: 400;
   float: right;
   color: #666;
+  text-transform: capitalize;
+  text-align: right;
+  max-width: 70%;
   /* border: 1px solid blue; */
 }
 

--- a/client/src/utils/getResourceTabTypes.js
+++ b/client/src/utils/getResourceTabTypes.js
@@ -1,0 +1,21 @@
+export default function getResourceTabTypes(tabs) {
+  let tabTypes = 'None';
+
+  if (Array.isArray(tabs)) {
+    tabTypes =
+      tabs &&
+      tabs
+        .reduce(
+          (acc, curr) => (acc.includes(curr) ? acc : acc.concat(curr)),
+          []
+        )
+        .join(', ');
+  } else if (typeof tabs === 'string') {
+    tabTypes = tabs;
+  }
+
+  tabTypes = tabTypes.replace('geogebra', 'GeoGebra');
+  const isPlural = tabTypes.includes(',');
+
+  return { tabTypes, isPlural };
+}


### PR DESCRIPTION
This PR allows users to view the types of tabs in a given room or template. 
UI changes include the following:
- SidePanel adjustments to shrink the space invader image to allow the Enter & Replayer buttons to be viewed w/o scrolling
- Center resource name text
- If a resource has multiple tabs, "Tab Types" is displayed, else "Tab Type" is displayed
- Tab Types shown in Tool TIps (hover over room-type icon)