### PR TITLE
:bug: fixed members & messages errors on admin mode switch

### DIFF
--- a/client/src/Components/Chat/Chat.js
+++ b/client/src/Components/Chat/Chat.js
@@ -575,7 +575,7 @@ class Chat extends Component {
                     <div className={classes.ChatButtons}>
                       <div
                         className={classes.Mic}
-                        key="qucikChat-ST"
+                        key="quickChat-ST"
                         title="Speech to text"
                         tabIndex={-3}
                         role="button"


### PR DESCRIPTION
Fixed bug where switching admin mode when in a room would incorrectly notify others of the admin or would leave "zombie" room members.