### PR TITLE
Assign groups update

### DIFF
--- a/client/src/Containers/Activity.js
+++ b/client/src/Containers/Activity.js
@@ -203,7 +203,7 @@ class Activity extends Component {
             }}
             label="Edit:"
             defaultOption={{ label: 'Change Room Assignments', value: [] }}
-            toolTip="edit blurb for tooltip"
+            toolTip="Editing assignments allows you to easily change the rooms that members are assigned to. You can also change the due date, the prefix for the room names, and whether or not to anonymize members while they're in the room."
             AssignmentComponent={EditRooms}
             optionsGenerator={createEditableAssignments}
           />
@@ -224,7 +224,7 @@ class Activity extends Component {
             }}
             label="Create:"
             defaultOption={{ label: 'New Grouping', value: [] }}
-            toolTip="assign blurb for tooltip"
+            toolTip="Create rooms for members to do math in. You can reuse the member groups that you create here."
             AssignmentComponent={MakeRooms}
             optionsGenerator={createPreviousAssignments}
             firstOption={{ label: 'New Grouping', value: [] }}

--- a/client/src/Containers/Create/MakeRooms/AssignRooms.js
+++ b/client/src/Containers/Create/MakeRooms/AssignRooms.js
@@ -57,16 +57,23 @@ const AssignRooms = (props) => {
           />
         )}
 
-        <Checkbox
-          light
-          name="aliasUsernames"
-          dataId="aliasUsernames"
-          style={{ width: '175px' }}
-          change={() => setAliasMode(!aliasMode)}
-          checked={aliasMode || false}
-        >
-          Alias Usernames?
-        </Checkbox>
+        <div className={classes.AliasInstructions}>
+          <Checkbox
+            light
+            name="aliasUsernames"
+            dataId="aliasUsernames"
+            style={{ width: '175px' }}
+            change={() => setAliasMode(!aliasMode)}
+            checked={aliasMode || false}
+          >
+            Alias Usernames?
+            <div className={classes.AliasTooltipContent}>
+              When selected, members in the room will be given a random
+              username. When not selected, members in the room will have their
+              normal usernames{' '}
+            </div>
+          </Checkbox>
+        </div>
 
         <TextInput
           light

--- a/client/src/Containers/Create/MakeRooms/AssignmentMatrix.js
+++ b/client/src/Containers/Create/MakeRooms/AssignmentMatrix.js
@@ -71,18 +71,28 @@ const AssignmentMatrix = (props) => {
               <th className={classes.LockedColumn}>
                 Participants{' '}
                 {onAddParticipants && (
-                  <i
-                    className={`fas fa-solid fa-plus ${classes.plus}`}
-                    title="Add Participants"
-                    onClick={() => {
-                      onAddParticipants(true);
-                    }}
-                    onKeyDown={() => {
-                      onAddParticipants(true);
-                    }}
-                    tabIndex={-1}
-                    role="button"
-                  />
+                  <div
+                    className={classes.AliasInstructions}
+                    style={{ display: 'inline' }}
+                  >
+                    <i
+                      className={`fas fa-solid fa-plus ${classes.plus}`}
+                      onClick={() => {
+                        onAddParticipants(true);
+                      }}
+                      onKeyDown={() => {
+                        onAddParticipants(true);
+                      }}
+                      tabIndex={-1}
+                      role="button"
+                    >
+                      <div className={classes.AliasTooltipContent}>
+                        Add participants. If you are within a Course,
+                        participants added here will be added to the Course
+                        members list.
+                      </div>
+                    </i>
+                  </div>
                 )}
               </th>
               {roomDrafts.map((room, i) => {

--- a/client/src/Containers/Create/MakeRooms/MakeRooms.js
+++ b/client/src/Containers/Create/MakeRooms/MakeRooms.js
@@ -42,44 +42,47 @@ const MakeRooms = (props) => {
 
   // if the selected assignment changes, reset the display
   useEffect(() => {
-    if (
-      selectedAssignment &&
-      Array.isArray(selectedAssignment.value) &&
-      selectedAssignment.value.length
-    ) {
+    if (selectedAssignment && Array.isArray(selectedAssignment.value)) {
       setRoomDrafts(selectedAssignment.value);
-      setParticipantsPerRoom(
-        Math.max(
-          Math.ceil(
-            filterFacilitators(participants).length /
-              selectedAssignment.value.length
-          ),
-          1
-        )
-      );
+      if (selectedAssignment.value.length !== 0) {
+        setParticipantsPerRoom(
+          Math.max(
+            Math.ceil(
+              filterFacilitators(participants).length /
+                selectedAssignment.value.length
+            ),
+            1
+          )
+        );
+      } else
+        setRoomNum(
+          Math.max(Math.ceil(filterFacilitators(participants).length / 3), 1),
+          true
+        );
     } else {
       setRoomNum(
         Math.max(Math.ceil(filterFacilitators(participants).length / 3), 1)
       );
     }
-  }, [selectedAssignment]);
+  }, [selectedAssignment, participants.length]);
 
-  const setRoomNum = (roomNum) => {
-    if (roomNum === roomDrafts.length) return;
+  const setRoomNum = (roomNum, clearRooms) => {
+    const newRoomDrafts = clearRooms ? [] : roomDrafts;
+    if (roomNum === newRoomDrafts.length) return;
     const requiredMembers = initialParticipants.filter(
       (mem) => mem.role === 'facilitator'
     );
     // Note that Array(n) creates an n length array, but with no values, so cannot map over them. Use fill() to fill the array with
     // undefined so the map will work. Alternatively, could do Array.from(Array(n)).
     const roomList =
-      roomNum > roomDrafts.length
-        ? roomDrafts
-            .concat(Array(roomNum - roomDrafts.length))
+      roomNum > newRoomDrafts.length
+        ? newRoomDrafts
+            .concat(Array(roomNum - newRoomDrafts.length))
             .fill()
             .map(() => ({
               members: [...requiredMembers],
             }))
-        : roomDrafts.slice(0, roomNum - roomDrafts.length);
+        : newRoomDrafts.slice(0, roomNum - newRoomDrafts.length);
     setRoomDrafts(roomList);
   };
 

--- a/client/src/Containers/Create/MakeRooms/makeRooms.css
+++ b/client/src/Containers/Create/MakeRooms/makeRooms.css
@@ -234,3 +234,31 @@
 .RoomNameInput {
   display: flex;
 }
+
+.AliasInstructions {
+  margin: auto 0;
+}
+
+.AliasTooltipContent {
+  display: none;
+  position: absolute;
+  /* margin-top: 2rem; */
+  margin-left: -2rem;
+  padding: 10px;
+  /* left: auto;
+  right: 65px; */
+  z-index: 1000;
+  box-shadow: lightShadow;
+  background: #2d91f2;
+  color: white;
+  border: 2px solid #ddd;
+  min-width: 250px;
+  /* width: max-content; */
+  max-width: 85%;
+  transition: 0.2s;
+}
+
+.AliasInstructions:hover .AliasTooltipContent {
+  display: flex;
+  animation: showDropdown 0.2s;
+}

--- a/client/src/Containers/Create/MakeRooms/selectAssignment.css
+++ b/client/src/Containers/Create/MakeRooms/selectAssignment.css
@@ -70,7 +70,7 @@
   .TooltipContent {
     display: none;
     position: absolute;
-    margin-top: 2rem;
+    margin-top: 1.1rem;
     padding: 10px;
     /* left: auto;
     right: 65px; */


### PR DESCRIPTION
This PR improves some functionality when creating new user groups for a template:
- adding participants automatically adjusts the number of rooms appropriately
- tooltips have been added for alias usernames, add participants, create groupings, and edit assignments
- after selecting a previous grouping, if you select New Grouping, it now clears the assignments