### PR TITLE
Update room details when leave a room

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -758,9 +758,8 @@ class Workspace extends Component {
   };
 
   goBack = () => {
-    const { populatedRoom, history } = this.props;
-    const { _id } = populatedRoom;
-    history.push(`/myVMT/rooms/${_id}/details`);
+    const { history } = this.props;
+    history.goBack();
   };
 
   setGraphCoords = (graphCoords) => {
@@ -1311,7 +1310,8 @@ Workspace.propTypes = {
     username: PropTypes.string,
   }).isRequired,
   temp: PropTypes.bool,
-  history: PropTypes.shape({ push: PropTypes.func }).isRequired,
+  history: PropTypes.shape({ push: PropTypes.func, goBack: PropTypes.func })
+    .isRequired,
   save: PropTypes.func,
   connectUpdateRoom: PropTypes.func.isRequired,
   connectUpdatedRoom: PropTypes.func.isRequired,

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -196,7 +196,7 @@ class Workspace extends Component {
 
   componentWillUnmount() {
     const { populatedRoom, connectUpdatedRoom, user } = this.props;
-    const { myColor, cancelSnapshots, currentMembers } = this.state;
+    const { myColor, cancelSnapshots, currentMembers, log, tabs } = this.state;
     // Only generate a LEAVE message (and remove the user from the currentMembers list) if:
     // - the user is in admin mode and is leaving via the exit button (i.e., not from switching mode)
     // - the user is leaving because they switched their admin mode on. They were in the room,
@@ -213,6 +213,8 @@ class Workspace extends Component {
         currentMembers: currentMembers.filter(
           (mem) => mem && user && mem._id !== user._id
         ),
+        chat: log.filter((msg) => msg.messageType),
+        tabs,
       });
     }
     window.removeEventListener('resize', this.resizeHandler);


### PR DESCRIPTION
Fixes a bug whereby the room details page (number of people in a room, number of tabs, number of messages) did not update after leaving a room. (A browser refresh would be needed.) Now the page updates with the correct information when the user leaves the room. 

Note: Room details is not "live" in the sense that it does not show updates based on other users that might still be in the room.