### PR TITLE
Update to ResourceList to display 1+ resources instead of 2+

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "dependencies": {
     "autoprefixer": "7.1.6",

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -142,7 +142,7 @@ const ResourceList = ({
             <h2 className={classes.ResourceHeader}>
               {displayResource} I Manage
             </h2>
-            {fList.length > 1 && setResourceState && (
+            {fList.length >= 1 && setResourceState && (
               <SortUI
                 keys={keys}
                 sortFn={facilitatorRequestSort}
@@ -165,7 +165,7 @@ const ResourceList = ({
             <h2 className={classes.ResourceHeader}>
               {displayResource} I&#39;m a member of
             </h2>
-            {pList.length > 1 && setResourceState && (
+            {pList.length >= 1 && setResourceState && (
               <SortUI
                 keys={keys}
                 sortFn={participantRequestSort}
@@ -193,7 +193,7 @@ const ResourceList = ({
               {displayResource} I&#39;m a member of
             </h2>
           )}
-          {(fList.length > 1 || pList.length > 1) && setResourceState && (
+          {(fList.length >= 1 || pList.length >= 1) && setResourceState && (
             <SortUI
               keys={keys}
               sortFn={


### PR DESCRIPTION
This pr is a temporary patch that allows users to see single resources, whereas before they only saw resources if there was more than 1.