### PR TITLE
In Course Stats, handle messages w/o users (old style)

### DIFF
--- a/client/src/Containers/Stats/stats.utils.js
+++ b/client/src/Containers/Stats/stats.utils.js
@@ -77,7 +77,7 @@ const processDataHelper = (
           };
 
           if (returnRoomAndUserIds) {
-            dataToReturn.userId = d.user._id || null;
+            dataToReturn.userId = (d.user && d.user._id) || null;
             dataToReturn.roomId = d.room || null;
           }
 


### PR DESCRIPTION
This pr adds backwards compatibility for Course Stats to handle messages without users.