### PR TITLE
Ensure messages have users before extracting userIds

### DIFF
--- a/client/src/Containers/Stats/CourseStats.js
+++ b/client/src/Containers/Stats/CourseStats.js
@@ -33,7 +33,7 @@ const CourseStats = ({ roomIds, name }) => {
     }, {});
 
     const userIds = Array.from(
-      new Set(filteredData.map((d) => d.userId.toString()))
+      new Set(filteredData.map((d) => (d.user && d.userId.toString()) || ''))
     );
     // query db for student ids
     return (


### PR DESCRIPTION
In CourseStats component, ensure messages have a user before extracting the message's user._id. This handles older cases where some messages do not have users.