### PR TITLE
Adjustments to re-import

### DIFF
--- a/client/src/Components/Importer/Importer.js
+++ b/client/src/Components/Importer/Importer.js
@@ -297,12 +297,13 @@ export default function Importer(props) {
           'username',
           user.username
         );
-        const { organization, identifier, ...rest } = user;
+        const { organization, identifier, isGmail, ...rest } = user;
         return existingUser
           ? {
               ...existingUser,
               metadata: { organization, identifier },
               sponsor: sponsors[user.username] || creator._id,
+              isGmail,
             }
           : {
               accountType: 'pending',

--- a/client/src/Containers/Course.js
+++ b/client/src/Containers/Course.js
@@ -398,6 +398,7 @@ class Course extends Component {
           <Members
             user={user}
             classList={this.sortParticipants(course.members)}
+            courseMembers={course.members}
             owner={course.myRole === 'facilitator' || isAdmin}
             resourceType="course"
             resourceId={course._id}


### PR DESCRIPTION
When importing an existing user, the isGmail flag may be updated (previously, only sponsor, institution, and identifier were updated). Additionally, the updated existing user no longer appears doubled in the course member list.