### PR TITLE
Revert "actuallyLogged in MyVMT routes uses cookies rather than store"

### DIFF
--- a/client/src/Routes/MyVmt.js
+++ b/client/src/Routes/MyVmt.js
@@ -82,6 +82,7 @@ const MyVmt = ({
   user,
   globalErrorMessage,
   connectUpdateUser,
+  loading,
 }) => {
   const toggleAdmin = () => {
     connectUpdateUser({ inAdminMode: !user.inAdminMode });
@@ -90,14 +91,10 @@ const MyVmt = ({
   const { path } = match;
   const { email, isEmailConfirmed } = user;
 
-  // when a user has a large redux store, reloading the takes seconds to
-  //  populate the store. Therefore, a user can be logged in but not registered
-  //  as such in the store. When a user is logged in and refreshes, the cookie
-  //  is immediately available.
-  const actuallyLoggedIn = document.cookie.indexOf('mt_sso_') > -1;
-
   const doRedirectToUnconfirmed =
-    actuallyLoggedIn && email.length > 0 && !isEmailConfirmed;
+    loggedIn && email.length > 0 && !isEmailConfirmed;
+
+  if (loading) return <Loading message="Loading the User" />;
 
   return (
     <ErrorBoundary>
@@ -148,6 +145,7 @@ MyVmt.propTypes = {
   }),
   globalErrorMessage: PropTypes.string,
   connectUpdateUser: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 MyVmt.defaultProps = {
@@ -158,6 +156,7 @@ MyVmt.defaultProps = {
 const mapStateToProps = (state) => ({
   loggedIn: state.user.loggedIn,
   user: state.user,
+  loading: state.loading.loading,
   globalErrorMessage: state.loading.globalErrorMessage,
 });
 


### PR DESCRIPTION
Reverts mathematicalthinking/vmt#576

The PrivateRoute authed prop needs to be configured to accept actuallyLoggedIn if not running on localhost, and logged in if running in localhost.