### PR TITLE
:tada: Detect if userid-socketid aren't connected in the database

### DIFF
--- a/client/src/Containers/Data/withPopulatedRoom.js
+++ b/client/src/Containers/Data/withPopulatedRoom.js
@@ -16,6 +16,7 @@ function withPopulatedRoom(WrappedComponent) {
     };
 
     componentDidMount() {
+      this.syncSocket();
       this.cancelFetch = false;
       const { match } = this.props;
       this.fetchRoom(match.params.room_id);
@@ -34,9 +35,18 @@ function withPopulatedRoom(WrappedComponent) {
       socket.removeAllListeners('RESET_COMPLETE');
     }
 
+    syncSocket = () => {
+      const { user: currentUser } = this.props;
+      socket.emit('SYNC_SOCKET', currentUser._id, (res, err) => {
+        if (err) console.error(err);
+        else console.log(res);
+      });
+    };
+
     syncRooms = async (user) => {
       this.cancelFetch = false;
       const { populatedRoom: oldRoom } = this.state;
+      this.syncSocket();
       socket.emit('RESET_ROOM', oldRoom._id, user);
     };
 

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -206,7 +206,7 @@ module.exports = function() {
       socketMetricInc('sync');
       if (!_id) {
         // console.log('unknown user connected: ', socket.id);
-        cb(null, 'NO USER');
+        cb(null, 'NO USER ID GIVEN TO SYNC_SOCKET');
         return;
       }
       socket.user_id = _id;
@@ -432,6 +432,11 @@ module.exports = function() {
         ['socketId'],
         socketsInRoom
       );
+      if (answer.length !== usersInRoom.length)
+        console.log(
+          `There are ${socketsInRoom.length -
+            answer.length} sockets with unknown users`
+        );
       return (answer || []).map((user) => user._id.toString());
     };
 


### PR DESCRIPTION
For whatever reason (networking glitches, etc.), occasionally a user would get into a state where they would be able to interact with a room, but they would not appear in the "Current Members" list. This happened because their socketId was not being recorded in the DB. This PR does the following:
* When the user enters a room, the system ensures that their socketId is recorded in the DB
* If a user finds that they are in this state (which shouldn't happen anymore because of the point above), selecting "Force Sync" will also fix the problem.
* Also included are some enhancements to server-side error messages surrounding this issue.