### PR TITLE
Fix the chat for monitors (detail/simple)

### DIFF
--- a/client/src/Components/Chat/SimpleChat.js
+++ b/client/src/Components/Chat/SimpleChat.js
@@ -48,6 +48,8 @@ function SimpleChat({ log, isSimplified }) {
     // setMessages(newMessages);
   };
 
+  React.useEffect(resetMessages, [isSimplified]);
+
   React.useEffect(() => {
     _scrollToBottom();
   }, []);

--- a/client/src/Containers/Monitoring/RoomViewer.js
+++ b/client/src/Containers/Monitoring/RoomViewer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { SimpleChat, ToggleGroup, CurrentMembers } from 'Components';
+import { SimpleChat, CurrentMembers, Slider } from 'Components';
 import Thumbnails from './Thumbnails';
 import classes from './roomViewer.css';
 
@@ -24,12 +24,7 @@ import classes from './roomViewer.css';
  */
 
 function RoomViewer({ populatedRoom }) {
-  const constants = {
-    SIMPLE: 'Simple Chat',
-    DETAILED: 'Detailed Chat',
-  };
-
-  const [chatType, setChatType] = React.useState(constants.DETAILED);
+  const [isSimplified, setIsSimplified] = React.useState(false);
 
   const toTimelineString = (timestamp) => {
     const oneWeekAgo = moment().subtract(7, 'days');
@@ -71,16 +66,17 @@ function RoomViewer({ populatedRoom }) {
             Chat
           </div>
           <div className={classes.Chat}>
-            <SimpleChat
-              isSimplified={chatType === constants.SIMPLE}
-              log={populatedRoom.chat}
+            <SimpleChat isSimplified={isSimplified} log={populatedRoom.chat} />
+          </div>
+          <div className={!isSimplified ? classes.SliderOn : classes.Slider}>
+            Detailed Chat
+            <Slider
+              data-testid="simple-chat"
+              action={() => setIsSimplified(!isSimplified)}
+              isOn={!isSimplified}
+              name="isSimplified"
             />
           </div>
-          <ToggleGroup
-            buttons={[constants.DETAILED, constants.SIMPLE]}
-            value={chatType}
-            onChange={setChatType}
-          />
         </div>
         <div className={classes.AttendanceSection}>
           <div

--- a/client/src/Containers/Monitoring/roomViewer.css
+++ b/client/src/Containers/Monitoring/roomViewer.css
@@ -64,4 +64,21 @@
     letter-spacing: 1.12px;
     cursor: pointer;
   }
+
+  .Slider {
+    margin: 5px auto;
+    padding: 5px;
+    border-radius: 3px;
+    display: flex;
+    justify-content: space-between;
+    box-shadow: lightShadow;
+    align-self: auto;
+    flex: 0 0 auto;
+    transition: 0.2s;
+  }
+  
+  .SliderOn {
+    composes: Slider;
+    font-weight: 600;
+  }
   


### PR DESCRIPTION
Switching between detailed and simple chat now works again in the monitors (general monitoring, course preview, etc.). For the room previewer, switching between detailed and simple chat now uses a similar UI as in a room.