### PR TITLE
Enhanced validation for email-username on import

### DIFF
--- a/client/src/Components/Importer/Importer.js
+++ b/client/src/Components/Importer/Importer.js
@@ -13,7 +13,7 @@ export default function Importer(props) {
   const [validationErrors, setValidationErrors] = React.useState([]);
   const [sponsors, setSponsors] = React.useState({});
   const buttonRef = React.createRef();
-  const { validateData, validateExistingField } = useDataValidation();
+  const { validateData, getUser } = useDataValidation();
 
   const handleOpenDialog = (e) => {
     // Note that the ref is set async, so it might be null at some point
@@ -86,10 +86,7 @@ export default function Importer(props) {
     const { user: creator, onImport } = props;
     const userObjects = await Promise.all(
       importedData.map(async (user) => {
-        const existingUser = await validateExistingField(
-          'username',
-          user.username
-        );
+        const existingUser = await getUser(user.username);
         const { organization, identifier, isGmail, ...rest } = user;
         return existingUser
           ? {

--- a/client/src/Components/Importer/Importer.js
+++ b/client/src/Components/Importer/Importer.js
@@ -1,12 +1,11 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { CSVReader } from 'react-papaparse';
-import { validateEmail, validateUsername, findMatchingUsers } from 'utils';
 import { Button } from 'Components';
 import ImportModal from './ImportModal';
+import useDataValidation from './dataValidation';
 
 export default function Importer(props) {
-  // props will be user, onImport, onCancel, preImportAction, buttonText
   const { buttonText, preImportAction } = props;
 
   const [showModal, setShowModal] = React.useState(false);
@@ -14,33 +13,7 @@ export default function Importer(props) {
   const [validationErrors, setValidationErrors] = React.useState([]);
   const [sponsors, setSponsors] = React.useState({});
   const buttonRef = React.createRef();
-  // Interestingly enough, when I made cachedData a state variable, it didn't update in time for the validation.
-  const cachedData = React.useRef([]);
-
-  const validateExistingField = (field, value) => {
-    return Promise.resolve(
-      cachedData.current.find((elt) => elt[field] === value)
-    ); // using a Promise to minimize code changes for now
-  };
-
-  const allValues = (field, data) =>
-    data
-      .map((elt) =>
-        typeof elt[field] === 'string' ? elt[field].toLowerCase() : elt[field]
-      )
-      .filter((val) => val && val !== '');
-
-  const preCacheData = async (data) => {
-    const usernames = Array.from(
-      new Set(allValues('username', data).concat(allValues('sponsor', data)))
-    );
-    const emails = Array.from(new Set(allValues('email', data)));
-    const results = await findMatchingUsers(
-      ['username', 'email'],
-      [...usernames, ...emails]
-    );
-    cachedData.current = results || [];
-  };
+  const { validateData, validateExistingField } = useDataValidation();
 
   const handleOpenDialog = (e) => {
     // Note that the ref is set async, so it might be null at some point
@@ -53,10 +26,11 @@ export default function Importer(props) {
     const extractedData = data
       .map((d) => d.data)
       .filter((d) => Object.values(d).some((val) => val !== '')); // ignore any blank lines
-    const [newData, newErrors] = await validateData(extractedData);
+    const [newData, newErrors, newSponsors] = await validateData(extractedData);
     setShowModal(true);
     setImportedData(newData);
     setValidationErrors(newErrors);
+    setSponsors(newSponsors);
   };
 
   const handleOnError = (err) => {
@@ -67,38 +41,26 @@ export default function Importer(props) {
     const newData = [...importedData];
     newData.splice(row, 1);
     setImportedData(newData, async () => {
-      const [imports, errors] = await validateData(newData);
+      const [imports, errors, newSponsors] = await validateData(newData);
       setImportedData(imports);
       setValidationErrors(errors);
+      setSponsors(newSponsors);
     });
   };
 
-  // 'changes' is an array of objects of the form {rowIndex, property: value}. For each unique row, we want to run
-  // the validator on the data in that row.
+  // 'changes' is an array of objects of the form {rowIndex, property: value}.
   const handleOnChanged = (changes) => {
-    const rowsToCheck = Array.from(new Set(changes.map((c) => c.rowIndex)));
-
-    // Make copies of the existing state -- data and errors. Clear out any errors among the rows we are revalidating (as
-    // specified within 'changes'). Make whatever changes to the data needed as per the 'changes' parameter
     const newData = [...importedData];
-    const newValidationErrors = validationErrors.filter(
-      (err) => !rowsToCheck.includes(err.rowIndex)
-    );
     changes.forEach(
       // eslint-disable-next-line no-return-assign
       ({ rowIndex, ...rest }) =>
         (newData[rowIndex] = { ...newData[rowIndex], ...rest })
     );
 
-    // revalidate the rows that had changes. Place each validated row into the correct place in the newData and merge
-    // any new errors
-    validateData(newData, rowsToCheck).then(([validatedData, errors]) => {
-      rowsToCheck.forEach(
-        // eslint-disable-next-line no-return-assign
-        (row, index) => (newData[row] = validatedData[index])
-      );
-      setImportedData(newData);
-      setValidationErrors([...newValidationErrors, ...errors]);
+    validateData(newData).then(([validatedData, errors, newSponsors]) => {
+      setImportedData(validatedData);
+      setValidationErrors(errors);
+      setSponsors(newSponsors);
     });
   };
 
@@ -108,186 +70,16 @@ export default function Importer(props) {
   // and highligt any relevant cells. If no issues, update the data, create any new users, and invite them to the course.
   const handleOnSubmit = async (data) => {
     if (validationErrors.length > 0) {
-      validateData(data).then(([newData, newValidationErrors]) => {
+      validateData(data).then(([newData, newValidationErrors, newSponsors]) => {
         setImportedData(newData);
         setValidationErrors(newValidationErrors);
+        setSponsors(newSponsors);
       });
     } else {
       if (preImportAction) await preImportAction();
       createAndInviteMembers();
       setShowModal(false);
     }
-  };
-
-  /**
-   * Checks the data in a row of a table. Returns an array with two elements:
-   * 1. the row of data (with any changes, such as comments)
-   * 2. an array of errors.
-   *
-   * The types of errors looked for:
-   * 1. Username/email: A mis-match between an existing username and email. In this case, we want to cue the resolution by
-   * the importer. The person can chose: (a) go by username (only if username exists), in which case the email for that username gets filled in. (b) go
-   * by email (only if the emailalready exists), in which case the username for that email is filled in, (c) create a new user.
-   * In case (c), if the username exists a new one is suggested. If the email exists, we clear it out (new user will have no
-   * email).
-   * 2. Usernames and emails are structured as per the validation patterns
-   * 3. Duplicate usernames or emails in the import list.
-   * 4. If a new user, first and last names must be there.
-   * 5. If a sponsor is given, it must be an existing user.
-   * 6. If an email is blank, this cannot be a gmail account.
-   */
-  const validateDataRow = async (dataRow, rowIndex) => {
-    // initialization, including default username if needed
-    const newValidationErrors = [];
-    const d = { ...dataRow };
-    if (!d.isGmail) d.isGmail = false; // initialize if needed
-    d.comment = '';
-    d.username = (
-      d.username.trim() || d.firstName.trim() + d.lastName.charAt(0)
-    ).toLowerCase();
-    if (d.email) {
-      d.email = d.email.toLowerCase().trim();
-    }
-
-    // 1. handle validating whether username/email exists, whether they are consistent, and the resolution thereof
-    const userFromUsername = await validateExistingField(
-      'username',
-      d.username
-    );
-    const userFromEmail = d.email
-      ? await validateExistingField('email', d.email)
-      : null;
-    const isMatch =
-      (userFromUsername &&
-        userFromEmail &&
-        userFromUsername._id === userFromEmail._id) ||
-      (userFromUsername && userFromUsername.email === d.email);
-    const isNewUser = !userFromEmail && !userFromUsername;
-
-    if (!isMatch && !isNewUser) {
-      newValidationErrors.push(
-        { rowIndex, property: 'username' },
-        { rowIndex, property: 'email' }
-      );
-      if (userFromUsername)
-        d.comment += `* Existing user ${d.username} should have email ${
-          userFromUsername.email !== '' ? userFromUsername.email : '<blank>'
-        }\n`;
-      if (userFromEmail)
-        d.comment += `* Existing email ${d.email} should be for user ${userFromEmail.username}\n`;
-    }
-
-    // 2. handle validating the structure of usernames and emails
-    const [emailResults, usernameResults] = await Promise.all([
-      // if no email, don't generate an error
-      validateEmail(d.email || 'dummy@dummy.com'),
-      validateUsername(d.username),
-    ]);
-
-    // eslint-disable-next-line no-unused-vars
-    const [emailError, validatedEmail] = emailResults;
-
-    // eslint-disable-next-line no-unused-vars
-    const [usernameError, validatedUsername] = usernameResults;
-
-    if (emailError) {
-      d.comment +=
-        '* Email is incorrectly formatted or has illegal characters\n';
-      newValidationErrors.push({ rowIndex, property: 'email' });
-    }
-
-    if (usernameError) {
-      d.comment += '* Username has illegal characters or is too long\n ';
-      newValidationErrors.push({ rowIndex, property: 'username' });
-    }
-
-    // 3. handle duplicate email or usernames in the list
-    let emailDup = 0;
-    let usernameDup = 0;
-    importedData.forEach((u) => {
-      if (u.username.toLowerCase() === d.username.toLowerCase()) {
-        usernameDup += 1;
-      }
-      if (!!u.email && u.email === d.email) {
-        emailDup += 1;
-      }
-    });
-
-    if (emailDup > 1) {
-      d.comment += '* Email duplicated in list\n';
-      newValidationErrors.push({ rowIndex, property: 'email' });
-    }
-
-    if (usernameDup > 1) {
-      d.comment += '* Username duplicated in list\n';
-      newValidationErrors.push({ rowIndex, property: 'username' });
-    }
-
-    // 4. handle validating that new users must have first and last names specified
-    if (isNewUser && (!d.firstName || !d.lastName)) {
-      d.comment += '* First and last names are required\n ';
-      if (!d.firstName)
-        newValidationErrors.push({ rowIndex, property: 'firstName' });
-      if (!d.lastName)
-        newValidationErrors.push({ rowIndex, property: 'lastName' });
-    }
-
-    // 5. handle validating that any specified sponsors must be existing users
-    if (d.sponsor && d.sponsor !== '') {
-      const { _id: sponsor_id } = (await validateExistingField(
-        'username',
-        d.sponsor
-      )) || { _id: undefined };
-      if (sponsor_id)
-        setSponsors((prevState) => ({
-          ...prevState.sponsors,
-          [d.username]: sponsor_id,
-        }));
-      else {
-        d.comment += "* Sponsor's username does not exist\n";
-        newValidationErrors.push({ rowIndex, property: 'sponsor' });
-      }
-    }
-
-    // 6. handle validating that a blank email cannot be a gmail account
-    if (d.email === '' && d.isGmail) {
-      d.comment += '* Google login may only be used if an email is specified\n';
-      newValidationErrors.push(
-        { rowIndex, property: 'email' },
-        { rowIndex, property: 'isGmail' }
-      );
-    }
-
-    return [d, newValidationErrors];
-  };
-
-  // Checks each row of the data for validation issues, returning an array of two elements:
-  // 1. the data with any changes (e.g., comments about what's wrong)
-  // 2. an array of pointers to the data that were problematic. Each element of the array is of the
-  //    form {rowIndex, property}, where rowIndex is the row of the line that contains the error and
-  //    property is the name of the data property that had the error.
-  //
-  // The rows argument is optional. If not given, goes through all data
-  const validateData = async (data, rows) => {
-    await preCacheData(data);
-    // first check for validation issues on all requested rows of the provided data, in parallel.
-    const validatedInfo = await Promise.all(
-      rows === undefined
-        ? data.map(async (d, index) => validateDataRow(d, index))
-        : rows.map(async (row) => validateDataRow(data[row], row))
-    );
-    // next, reconfigure the results of the above call so that we accumulate the data rows and errors
-    // gathered above. validatedData will be an array of each row. For validationsErrors, because there can be
-    // more than one error on each row, we have to use a spread operator in accumulation so that we
-    // end up wth a simple array of errors.
-    const [validatedData, newErrors] = await validatedInfo.reduce(
-      ([accData, accErrors], [dataRow, rowErrors]) => [
-        [...accData, dataRow],
-        [...accErrors, ...rowErrors],
-      ],
-      [[], []]
-    );
-    return [validatedData, newErrors];
   };
 
   const createAndInviteMembers = async () => {

--- a/client/src/Components/Importer/dataValidation.js
+++ b/client/src/Components/Importer/dataValidation.js
@@ -1,0 +1,290 @@
+import React from 'react';
+import { findMatchingUsers } from 'utils';
+
+export default function useDataValidation() {
+  const [sponsors, setSponsors] = React.useState({});
+  const cachedData = React.useRef([]);
+
+  const validateExistingFieldAsync = (field, value) => {
+    return Promise.resolve(validateExistingField(field, value)); // using a Promise to minimize code changes for now
+  };
+
+  const validateExistingField = (field, value) => {
+    return cachedData.current.find((elt) => elt[field] === value);
+  };
+
+  const allValues = (field, data) =>
+    data
+      .map((elt) =>
+        typeof elt[field] === 'string' ? elt[field].toLowerCase() : elt[field]
+      )
+      .filter((val) => val && val !== '');
+
+  const preCacheData = async (data) => {
+    const usernames = Array.from(
+      new Set(allValues('username', data).concat(allValues('sponsor', data)))
+    );
+    const emails = Array.from(new Set(allValues('email', data)));
+    const results = await findMatchingUsers(
+      ['username', 'email'],
+      [...usernames, ...emails]
+    );
+    cachedData.current = results || [];
+  };
+
+  const dummyStrategy = {
+    validationErrors: [],
+    comment: '',
+    setProperties: [],
+  };
+
+  // This object reflects how to handle the 9 different cases when username and email are existing, new, or blank.
+  // (actually, there are 11 cases; two of the strategies below handle two cases each.)
+  const usernameEmailStrategy = {
+    // username and email blank
+    0: (rowIndex) => ({
+      ...dummyStrategy,
+      validationErrors: [{ rowIndex, property: 'username' }],
+      comment: '* Must specify username for a new user.\n',
+    }),
+    // username blank, email of existing user
+    1: (rowIndex, userFromUsername, userFromEmail) => ({
+      ...dummyStrategy,
+      validationErrors: [{ rowIndex, property: 'username' }],
+      comment: '* Username filled in from existing user (based on email).\n',
+      setProperties: [{ property: 'username', value: userFromEmail.username }],
+    }),
+    // username blank, email is new
+    2: (rowIndex) => ({
+      ...dummyStrategy,
+      validationErrors: [{ rowIndex, property: 'username' }],
+      comment: '* Must specify username for a new user.\n',
+    }),
+    // username is of existing user, email is blank. If email supposed to be blank, it's a valid situation.
+    3: (rowIndex, userFromUsername, userFromEmail) =>
+      userFromUsername.email === ''
+        ? { ...dummyStrategy }
+        : {
+            ...dummyStrategy,
+            validationErrors: [{ rowIndex, property: 'email' }],
+            comment:
+              '* Email filled in from existing user (based on username).\n',
+            setProperties: [
+              { property: 'email', value: userFromUsername.email },
+            ],
+          },
+    // username is of existing user, email is of existing user. If they match, it's a valid situation
+    4: (rowIndex, userFromUsername, userFromEmail) =>
+      userFromUsername._id === userFromEmail._id
+        ? { ...dummyStrategy }
+        : {
+            ...dummyStrategy,
+            validationErrors: [
+              { rowIndex, property: 'email' },
+              { rowIndex, property: 'username' },
+            ],
+            comment: `* Username-email mismatch. Replace username with ${userFromEmail.username} or email with ${userFromUsername.email}.\n`,
+          },
+    // username is of existing user, email is new
+    5: (rowIndex, userFromUsername, userFromEmail) => ({
+      validationErrors: [{ rowIndex, property: 'email' }],
+      comment: `* Imported email corrected for existing user ${userFromUsername.username}.\n`,
+      setProperties: [{ property: 'email', value: userFromUsername.email }],
+    }),
+    // username is new, email is blank (valid situation)
+    6: () => ({ ...dummyStrategy }),
+    // username is new, email is of existing user
+    7: (rowIndex, userFromUsername, userFromEmail) => ({
+      validationErrors: [{ rowIndex, property: 'username' }],
+      comment:
+        '* Imported username corrected for existing user (based on email).\n',
+      setProperties: [{ property: 'username', value: userFromEmail.username }],
+    }),
+    // username is new, email is new (valid situation)
+    8: () => ({ ...dummyStrategy }),
+  };
+
+  const getUsernameEmailState = (username, email) => {
+    const userFromUsername = username
+      ? validateExistingField('username', username)
+      : null;
+    const userFromEmail = email ? validateExistingField('email', email) : null;
+
+    let userState;
+    if (userFromUsername) userState = 1;
+    else if (username === '') userState = 0;
+    else userState = 2;
+
+    let emailState;
+    if (userFromEmail) emailState = 1;
+    else if (email === '') emailState = 0;
+    else emailState = 2;
+
+    const state = userState * 3 + emailState;
+
+    return [userFromUsername, userFromEmail, state];
+  };
+
+  /**
+   * Checks the data in a row of a table. Returns an array with two elements:
+   * 1. the row of data (with any changes, such as comments)
+   * 2. an array of errors.
+   *
+   * The types of errors looked for:
+   * 1. Username/email: Different strategies are used depending on whether the username and email are existing, new, or blank.
+   *    See the different strategies in the object usernameEmailStrategy above.
+   * 4. If a new user, first and last names must be there.
+   * 5. If a sponsor is given, it must be an existing user.
+   * 6. If an email is blank, this cannot be a gmail account.
+   */
+
+  const validateDataRow = (dataRow, rowIndex) => {
+    // initialization, including default username if needed
+    const newValidationErrors = [];
+    const d = { ...dataRow };
+    if (!d.isGmail) d.isGmail = false; // initialize if needed
+    d.comment = '';
+    if (d.username) d.username = d.username.toLowerCase().trim();
+    if (d.email) {
+      d.email = d.email.toLowerCase().trim();
+    }
+
+    // 1. handle validating whether username/email exists, whether they are consistent, and the resolution thereof
+    const [
+      userFromUsername,
+      userFromEmail,
+      usernameEmailState,
+    ] = getUsernameEmailState(d.username, d.email);
+
+    const strategy = usernameEmailStrategy[usernameEmailState](
+      rowIndex,
+      userFromUsername,
+      userFromEmail
+    );
+    newValidationErrors.push(...strategy.validationErrors);
+    d.comment += strategy.comment;
+    strategy.setProperties.forEach(
+      // eslint-disable-next-line no-return-assign
+      ({ property, value }) => (d[property] = value)
+    );
+
+    // 4. handle validating that new users must have first and last names specified
+    const isNewUser = !userFromEmail && !userFromUsername;
+    if (isNewUser && (!d.firstName || !d.lastName)) {
+      d.comment += '* First and last names are required for new users.\n ';
+      if (!d.firstName)
+        newValidationErrors.push({ rowIndex, property: 'firstName' });
+      if (!d.lastName)
+        newValidationErrors.push({ rowIndex, property: 'lastName' });
+    }
+
+    // 5. handle validating that any specified sponsors must be existing users
+    if (d.sponsor && d.sponsor !== '') {
+      const { _id: sponsor_id } = validateExistingField(
+        'username',
+        d.sponsor
+      ) || { _id: undefined };
+      if (sponsor_id)
+        setSponsors((prevState) => ({
+          ...prevState.sponsors,
+          [d.username]: sponsor_id,
+        }));
+      else {
+        d.comment += "* Teacher's username does not exist.\n";
+        newValidationErrors.push({ rowIndex, property: 'sponsor' });
+      }
+    }
+
+    // 6. handle validating that a blank email cannot be a gmail account
+    if (d.email === '' && d.isGmail) {
+      d.comment +=
+        '* Google login may only be used if an email is specified.\n';
+      newValidationErrors.push(
+        { rowIndex, property: 'email' },
+        { rowIndex, property: 'isGmail' }
+      );
+    }
+
+    return [d, newValidationErrors];
+  };
+
+  // return an error array for any duplicates in the 'property' column of the data.
+  const duplicateFinder = (data, property) => {
+    const values = data.map((dataRow) => dataRow[property]);
+    const duplicatedRows = data.reduce((acc, dataRow, rowIndex) => {
+      const loc = values.indexOf(dataRow[property]);
+      if (loc !== rowIndex) {
+        acc.add(loc);
+        acc.add(rowIndex);
+      }
+      return acc;
+    }, new Set());
+    return Array.from(duplicatedRows).map((rowIndex) => ({
+      rowIndex,
+      property,
+    }));
+  };
+
+  // return an error array for duplicates in all the properties columns of the data.
+  const findDuplicates = (data, properties) => {
+    return properties.reduce(
+      (acc, property) => [...acc, ...duplicateFinder(data, property)],
+      []
+    );
+  };
+
+  // Checks each row of the data for validation issues, returning an array of three elements:
+  // 1. the data with any changes (e.g., comments about what's wrong)
+  // 2. an array of pointers to the data that were problematic. Each element of the array is of the
+  //    form {rowIndex, property}, where rowIndex is the row of the line that contains the error and
+  //    property is the name of the data property that had the error.
+  // 3. all of the sponsors represented in the data (used by the client)
+  //
+  // The rows argument is optional. If not given, we go through all data
+  const validateData = async (data, rows) => {
+    await preCacheData(data);
+
+    // check for duplicates; don't do any other validation if we find duplicates
+    const duplicateErrors = findDuplicates(data, ['username', 'email']);
+    if (duplicateErrors.length > 0) {
+      const commentsForDuplicates = duplicateErrors.reduce(
+        (acc, error) => ({
+          ...acc,
+          [error.rowIndex]: (acc[error.rowIndex] || '').concat(
+            `* Duplicated ${error.property}.\n`
+          ),
+        }),
+        {}
+      );
+      const validatedData = data.map((dataRow, index) => ({
+        ...dataRow,
+        comment: commentsForDuplicates[index] || '',
+      }));
+      return [validatedData, duplicateErrors, sponsors];
+    }
+
+    // check for validation issues on all requested rows of the provided data, in parallel.
+    // Note that right now, validateDataRow isn't async, so unclear whether we are saving any time using Promise.all
+    const validatedInfo = await Promise.all(
+      rows === undefined
+        ? data.map(async (d, index) => validateDataRow(d, index))
+        : rows.map(async (row) => validateDataRow(data[row], row))
+    );
+
+    // Reconfigure the results of the above call so that we accumulate the data rows and errors
+    // gathered above. validatedData will be an array of each row. For validationsErrors, because there can be
+    // more than one error on each row, we have to use a spread operator in accumulation so that we
+    // end up wth a simple array of errors.
+    const [validatedData, newErrors] = await validatedInfo.reduce(
+      ([accData, accErrors], [dataRow, rowErrors]) => [
+        [...accData, dataRow],
+        [...accErrors, ...rowErrors],
+      ],
+      [[], []]
+    );
+    return [validatedData, newErrors, sponsors];
+  };
+
+  // return validateExistingField as an async function because in the future, it might be one.
+  return { validateData, validateExistingField: validateExistingFieldAsync };
+}

--- a/client/src/Components/Importer/dataValidation.js
+++ b/client/src/Components/Importer/dataValidation.js
@@ -2,13 +2,8 @@ import React from 'react';
 import { findMatchingUsers } from 'utils';
 
 /**
- * useDataValidation is a custom hook for validating (and correcting) imported user data.  The hook provides two functions, validateData (takes a data array
- * and returns an array of validatedData, errors, and a new sponsor object) and getUser (takes a username and returns the user object from the cache, if it exists).
- *
- * Note: This hook could be made more React-like if it worked as follows:
- *    const {validatedData, validationErrors, sponsors} = useDataValidation(importedData)
- *
- *    Each time importedData changes, validation would automatically run, in turn updating validatedData, validationErrors, and sponsors.
+ * useDataValidation is a custom hook for validating (and correcting) imported user data.  Given importedData, the hook provides the updated data, errors, and sponsors.
+ * The hook also provides getUser, a function that gets a user object from the 'db' (actually a cache) if it exists.
  */
 
 export default function useDataValidation(importedData) {


### PR DESCRIPTION
This PR changes the way that import validation works:

* If either the username or email (but not both) is for an existing user, the correct email or username is filled in.
* If the username and email indicate different existing users, the additional information is provided in the comments.
* The system no longer validates the structure or length of usernames or emails.
* Duplicate usernames or emails across rows are checked for before any other validation is done.