### PR TITLE
adjust control warning message

### DIFF
--- a/client/src/Containers/Workspace/ControlWarningModal.js
+++ b/client/src/Containers/Workspace/ControlWarningModal.js
@@ -10,7 +10,7 @@ const ControlWarningModal = ({
   showControlWarning,
   inAdminMode,
 }) => {
-  let msg = `You can't make updates when you're not in control. Click "Take Control" first.`;
+  let msg = `You can't make updates when you're not in control.`;
   let cancelText = 'Cancel';
   let cancelTheme = 'Cancel';
 
@@ -39,7 +39,7 @@ const ControlWarningModal = ({
       }
     })();
 
-    return { text, default: false };
+    return { text, disabled: false };
   };
 
   return (

--- a/client/src/Containers/Workspace/ControlWarningModal.js
+++ b/client/src/Containers/Workspace/ControlWarningModal.js
@@ -14,6 +14,8 @@ const ControlWarningModal = ({
   let cancelText = 'Cancel';
   let cancelTheme = 'Cancel';
 
+  if (inControl === 'REQUESTED') msg += ` You've already requested control.`;
+
   if (inAdminMode) {
     msg = "You can't make updates when you're in admin mode.";
     cancelText = 'Okay';


### PR DESCRIPTION
Made control warning modal message more generic. The 'call to action' is implied by the text of the highlighted button.