### PR TITLE
Refactor archive to pull ids from backend

### DIFF
--- a/client/src/Containers/Archive.js
+++ b/client/src/Containers/Archive.js
@@ -55,7 +55,14 @@ const Archive = () => {
     roomType,
   ]);
 
-  const debounceFetchData = debounce(() => fetchData(), 1000);
+  useEffect(() => {
+    if (skip > 0) debounceFetchData(true);
+  }, [skip]);
+
+  const debounceFetchData = debounce(
+    (concat = false) => fetchData(concat),
+    1000
+  );
 
   const debouncedSetCriteria = debounce((criteria) => {
     const filters = getQueryParams();
@@ -142,7 +149,7 @@ const Archive = () => {
 
     if (archive && archive[resource] && archive[resource].length > 0) {
       API.searchPaginatedArchive(resource, updatedFilters.search, skip, {
-        ids: archive[resource],
+        // ids: archive[resource], // do this server side
         ...updatedFilters,
         // roomType: updatedFilters.roomType,
       })
@@ -151,10 +158,9 @@ const Archive = () => {
           setLoading(false);
           setMoreAvailable(isMoreAvailable);
           setVisibleResources((prevState) =>
-            concat
-              ? [...prevState.visibleResources].concat(res.data.results)
-              : res.data.results
+            concat ? [...prevState].concat(res.data.results) : res.data.results
           );
+          // concat ? setVisibleResources((prevState) [...prevState.v])
         })
         .catch((err) => {
           // eslint-disable-next-line no-console
@@ -171,14 +177,9 @@ const Archive = () => {
   };
 
   const setSkipState = () => {
-    setSkip(
-      (prevState) => ({
-        skip: prevState.skip + SKIP_VALUE,
-      }),
-      () => {
-        fetchData(true);
-      }
-    );
+    setSkip((prevState) => prevState + SKIP_VALUE);
+    // skip.current += SKIP_VALUE;
+    // console.log(`setSkipState, skip.current: ${skip.current}`);
   };
 
   const clearSearch = () => {
@@ -230,7 +231,7 @@ const Archive = () => {
 
   const getResourceNames = (ids) => {
     return visibleResources
-      .filter((resource) => ids.includes(resource._id))
+      .filter((res) => ids.includes(res._id))
       .map((res) => res.name);
   };
 
@@ -286,7 +287,7 @@ const Archive = () => {
           Are you sure you want to restore{' '}
           <span style={{ fontWeight: 'bolder' }}>{resourceNames}</span>
         </span>
-        <div className={''}>
+        <div className="">
           <Button
             data-testid="restore-resource"
             click={() => {

--- a/client/src/Containers/Archive.js
+++ b/client/src/Containers/Archive.js
@@ -140,7 +140,6 @@ const Archive = () => {
   const fetchData = (concat = false) => {
     setLoading(true);
     const filters = getQueryParams();
-    // if filter = all we're not actually filtering...we want all
     const updatedFilters = { ...filters };
 
     if (updatedFilters.roomType === 'all') {
@@ -149,9 +148,7 @@ const Archive = () => {
 
     if (archive && archive[resource] && archive[resource].length > 0) {
       API.searchPaginatedArchive(resource, updatedFilters.search, skip, {
-        // ids: archive[resource], // do this server side
         ...updatedFilters,
-        // roomType: updatedFilters.roomType,
       })
         .then((res) => {
           const isMoreAvailable = res.data.results.length >= SKIP_VALUE;
@@ -160,7 +157,6 @@ const Archive = () => {
           setVisibleResources((prevState) =>
             concat ? [...prevState].concat(res.data.results) : res.data.results
           );
-          // concat ? setVisibleResources((prevState) [...prevState.v])
         })
         .catch((err) => {
           // eslint-disable-next-line no-console
@@ -178,8 +174,6 @@ const Archive = () => {
 
   const setSkipState = () => {
     setSkip((prevState) => prevState + SKIP_VALUE);
-    // skip.current += SKIP_VALUE;
-    // console.log(`setSkipState, skip.current: ${skip.current}`);
   };
 
   const clearSearch = () => {

--- a/client/src/Layout/Archive/Archive.js
+++ b/client/src/Layout/Archive/Archive.js
@@ -10,7 +10,7 @@ const Archive = (props) => {
     visibleResources,
     resource,
     searchValue,
-    setSkipState,
+    setSkip,
     setCriteria,
     moreAvailable,
     filters,
@@ -237,7 +237,7 @@ const Archive = (props) => {
                 selectActions={selectActions}
               />
               <div className={classes.LoadMore}>
-                <Button m={20} disabled={!moreAvailable} click={setSkipState}>
+                <Button m={20} disabled={!moreAvailable} click={setSkip}>
                   load more results
                 </Button>
               </div>
@@ -253,7 +253,7 @@ Archive.propTypes = {
   visibleResources: PropTypes.arrayOf(PropTypes.shape({})),
   resource: PropTypes.string.isRequired,
   searchValue: PropTypes.string,
-  setSkipState: PropTypes.func,
+  setSkip: PropTypes.func,
   setCriteria: PropTypes.func.isRequired,
   moreAvailable: PropTypes.bool.isRequired,
   filters: PropTypes.shape({
@@ -278,7 +278,7 @@ Archive.propTypes = {
 Archive.defaultProps = {
   visibleResources: [],
   searchValue: '',
-  setSkipState: () => {},
+  setSkip: () => {},
   customFromDate: null,
   customToDate: null,
   roomPreviewComponent: null,

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -7,7 +7,7 @@ import { useSortableData, timeFrames } from 'utils';
 import SelectableBoxList from 'Layout/SelectableBoxList/SelectableBoxList';
 import { Button, Modal, BigModal, Search, ToolTip } from 'Components';
 import { RoomPreview } from 'Containers';
-import { updateRoom } from 'store/actions';
+import { updateRoom, archiveRooms } from 'store/actions';
 import { STATUS } from 'constants.js';
 import BoxList from '../../BoxList/BoxList';
 import NewResource from '../../../Containers/Create/NewResource/NewResource';
@@ -260,21 +260,11 @@ const ResourceList = ({
     const dispatchArchive = () => {
       if (singleResource) {
         const rtnObj = {
-          ...userResources.find((userResource) => userResource._id === id),
           status: STATUS.ARCHIVED,
         };
         dispatch(updateRoom(id, rtnObj));
       } else {
-        id.forEach((resId) => {
-          dispatch(
-            updateRoom(resId, {
-              ...userResources.find(
-                (userResource) => userResource._id === resId
-              ),
-              status: STATUS.ARCHIVED,
-            })
-          );
-        });
+        dispatch(archiveRooms(id));
       }
     };
 

--- a/client/src/store/actions/index.js
+++ b/client/src/store/actions/index.js
@@ -59,6 +59,7 @@ export {
   updateMonitorSelections,
   createGrouping,
   restoreArchivedRoom,
+  archiveRooms,
 } from './rooms';
 export {
   getCourses,

--- a/client/src/utils/apiRequests.js
+++ b/client/src/utils/apiRequests.js
@@ -200,4 +200,8 @@ export default {
   reinstateUser: (userId) => {
     return api.post(`/admin/reinstateUser/${userId}`);
   },
+
+  archiveRooms: (ids) => {
+    return api.put(`/api/archiveRooms`, { ids });
+  },
 };

--- a/server/middleware/utils/request.js
+++ b/server/middleware/utils/request.js
@@ -25,6 +25,14 @@ const getResource = (req) => {
   return _.propertyOf(req)('params.resource');
 };
 
+const setResource = (req, resource) => {
+  return { ...req, params: { resource } };
+};
+
+const setParamsId = (req, id) => {
+  return { ...req, params: { ...req.params, id } };
+};
+
 const getParamsId = (req) => {
   return _.propertyOf(req)('params.id');
 };
@@ -141,7 +149,9 @@ const signJwt = (payload, secret, options) => {
 
 module.exports.getUser = getUser;
 module.exports.getResource = getResource;
+module.exports.setResource = setResource;
 module.exports.getParamsId = getParamsId;
+module.exports.setParamsId = setParamsId;
 module.exports.isValidMongoId = isValidMongoId;
 module.exports.isModifyRequest = isModifyRequest;
 module.exports.schemaHasProperty = schemaHasProperty;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -12,8 +12,11 @@ const {
   getUser,
   getResource,
   getParamsId,
+  setResource,
+  setParamsId,
 } = require('../middleware/utils/request');
 const { findAllMatching } = require('../middleware/utils/helpers');
+const status = require('../constants/status');
 
 router.param('resource', middleware.validateResource);
 router.param('id', middleware.validateId);
@@ -26,6 +29,7 @@ router.get('/:resource', middleware.validateUser, (req, res) => {
     .get(req.query)
     .then((results) => res.json({ results }))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error get ${resource}: ${err}`);
       let msg = null;
 
@@ -51,6 +55,7 @@ router.post('/:resource/code', (req, res) => {
     .getByCode(code)
     .then((result) => res.json({ result }))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error: unable to retrieve resource via code`);
       let msg = null;
 
@@ -80,6 +85,7 @@ router.get('/search/:resource', (req, res) => {
       res.json({ results });
     })
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error search ${resource}: ${err}`);
       let msg = null;
       if (typeof err === 'string') {
@@ -106,6 +112,7 @@ router.get('/searchPaginated/:resource', (req, res) => {
       res.json({ results });
     })
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error search paginated${resource}: ${err}`);
       let msg = null;
       if (typeof err === 'string') {
@@ -120,12 +127,22 @@ router.get('/searchPaginatedArchive/:resource', (req, res) => {
   const controller = controllers[resource];
   const { searchText, skip, filters } = req.query;
   const regex = searchText ? new RegExp(searchText, 'i') : '';
+
+  // add user's archived ids from db onto filters
+  const user = getUser(req);
+  const archiveIds =
+    user.archive && user.archive[resource] ? user.archive[resource] : [];
+
+  const filtersAdjusted = JSON.parse(filters);
+  filtersAdjusted.ids = archiveIds;
+
   controller
-    .searchPaginatedArchive(regex, skip, JSON.parse(filters))
+    .searchPaginatedArchive(regex, skip, filtersAdjusted)
     .then((results) => {
       res.json({ results });
     })
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error search paginated archive ${resource}: ${err}`);
       let msg = null;
       if (typeof err === 'string') {
@@ -144,6 +161,7 @@ router.get('/findAllMatching/:resource', (req, res) => {
   findAllMatching(controller, fields, values)
     .then((results) => res.json({ results }))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error get ${resource}: ${err}`);
       let msg = null;
 
@@ -170,6 +188,7 @@ router.get('/findAllMatchingIds/:resource/populated', (req, res) => {
       )
     ).then((results) => res.json({ results }));
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error(`Error get ${resource}: ${err}`);
     let msg = null;
 
@@ -208,6 +227,7 @@ router.get('/dashboard/:resource', middleware.validateUser, (req, res) => {
     .getRecentActivity(regex, skip, filters)
     .then((results) => res.json({ results }))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error admin/dashboard/${resource}: ${err}`);
 
       let msg = null;
@@ -234,6 +254,7 @@ router.get(
         res.json({ result });
       })
       .catch((err) => {
+        // eslint-disable-next-line no-console
         console.error(`Error get populated ${resource}/${id}: ${err}`);
         let msg = null;
 
@@ -255,6 +276,7 @@ router.get('/:resource/:id', middleware.validateUser, (req, res) => {
     .getById(id, req.query)
     .then((result) => res.json({ result }))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error get ${resource}/${id}: ${err}`);
       let msg = null;
 
@@ -276,6 +298,7 @@ router.get('/:resource/:id/:tempRoom', (req, res) => {
     .getPopulatedById(id, req.query)
     .then((result) => res.json({ result }))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error get ${resource}/${id}: ${err}`);
       let msg = null;
 
@@ -326,6 +349,7 @@ router.post(
       .post(req.body)
       .then((result) => res.json({ result }))
       .catch((err) => {
+        // eslint-disable-next-line no-console
         console.error(`Error post ${req.params.resource}: ${err}`);
 
         let msg = null;
@@ -367,6 +391,7 @@ router.put('/:resource/:id/add', middleware.validateUser, (req, res) => {
     })
     .then((result) => res.json(result))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error put/add ${resource}/${id}: ${err}`);
 
       let msg = null;
@@ -405,6 +430,7 @@ router.put('/:resource/:id/remove', middleware.validateUser, (req, res) => {
     })
     .then((result) => res.json(result))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error put/remove/${resource}/${id}: ${err}`);
 
       let msg = null;
@@ -417,7 +443,8 @@ router.put('/:resource/:id/remove', middleware.validateUser, (req, res) => {
     });
 });
 
-router.put('/:resource/:id', middleware.validateUser, (req, res) => {
+// updateResource is a helper fn for the following 2 put methods
+const updateResource = (req, res) => {
   const id = getParamsId(req);
   const resource = getResource(req);
   const controller = controllers[resource];
@@ -427,26 +454,43 @@ router.put('/:resource/:id', middleware.validateUser, (req, res) => {
   if (resource === 'events') {
     return errors.sendError.BadMethodError('Events cannot be modified!', res);
   }
-  return middleware
-    .canModifyResource(req)
-    .then((results) => {
-      const { canModify, doesRecordExist, details } = results;
+  return middleware.canModifyResource(req).then((results) => {
+    const { canModify, doesRecordExist, details } = results;
 
-      if (!doesRecordExist) {
-        return errors.sendError.NotFoundError(null, res);
-      }
+    if (!doesRecordExist) {
+      return errors.sendError.NotFoundError(null, res);
+    }
 
-      if (!canModify) {
-        return errors.sendError.NotAuthorizedError(
-          'You do not have permission to modify this resource',
-          res
-        );
-      }
-      const prunedBody = middleware.prunePutBody(user, id, req.body, details);
-      return controller.put(id, prunedBody);
-    })
+    if (!canModify) {
+      return errors.sendError.NotAuthorizedError(
+        'You do not have permission to modify this resource',
+        res
+      );
+    }
+    const prunedBody = middleware.prunePutBody(user, id, req.body, details);
+    return controller.put(id, prunedBody);
+  });
+  // .then((result) => res.json(result))
+  // .catch((err) => {
+  //   console.error(`Error put ${resource}/${id}: ${err}`);
+
+  //   let msg = null;
+
+  //   if (typeof err === 'string') {
+  //     msg = err;
+  //   }
+
+  //   return errors.sendError.InternalError(msg, res);
+  // });
+};
+
+router.put('/:resource/:id', middleware.validateUser, (req, res) => {
+  const id = getParamsId(req);
+  const resource = getResource(req);
+  updateResource(req, res)
     .then((result) => res.json(result))
     .catch((err) => {
+      // eslint-disable-next-line no-console
       console.error(`Error put ${resource}/${id}: ${err}`);
 
       let msg = null;
@@ -457,6 +501,37 @@ router.put('/:resource/:id', middleware.validateUser, (req, res) => {
 
       return errors.sendError.InternalError(msg, res);
     });
+});
+
+router.put('/archiveRooms', (req, res) => {
+  const { ids = [] } = req.body;
+  const body = { status: status.ARCHIVED };
+
+  const updatedReq = setResource(req, 'rooms');
+
+  return Promise.all(
+    ids.map((id) => {
+      const newReq = setParamsId(updatedReq, id);
+      return updateResource(
+        {
+          ...newReq,
+          body,
+        },
+        res
+      ).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(`Error put rooms/${id}: ${err}`);
+
+        let msg = null;
+
+        if (typeof err === 'string') {
+          msg = err;
+        }
+
+        return errors.sendError.InternalError(msg, res);
+      });
+    })
+  ).then(() => res.sendStatus(200));
 });
 
 // router.delete("/:resource/:id", middleware.validateUser, (req, res, next) => {


### PR DESCRIPTION
User's archived room ids are now generated from the back end as opposed to being passed in the headers from the front end. This enables a far greater number of archived ids to be passed from the BE to the FE.

Various bug fixes