### PR TITLE
Thumbnail defaults

### DIFF
--- a/client/src/Containers/Monitoring/Thumbnails.js
+++ b/client/src/Containers/Monitoring/Thumbnails.js
@@ -188,7 +188,9 @@ export default function Thumbnails({
 }
 
 Thumbnails.propTypes = {
-  populatedRoom: PropTypes.shape({}).isRequired,
+  populatedRoom: PropTypes.shape({
+    tabs: PropTypes.arrayOf(PropTypes.shape({})),
+  }).isRequired,
   defaultLabel: PropTypes.string,
   initialTabIndex: PropTypes.number,
   initialScreen: PropTypes.number,


### PR DESCRIPTION
Currently, when a user monitors a room (either via general monitoring, course preview, template preview, or room preview), the thumbnail tab will show the most recently updated thumbnail/screen snapshot. However, if there are multiple tabs or Desmos activity screens, the pull-down menu didn't display which tab/screen that most recent thumbnail is from.

This PR fixes that error. Whatever thumbnail is being shown is now reflected in the pull down menu.

(Note: Because the line endings changed from CRLF to LF, it looks like the entire file changed.)