### PR TITLE
App level modal

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import { QueryClientProvider, QueryClient } from 'react-query';
 import MyVmt from './Routes/MyVmt';
 import Home from './Routes/Home';
 import SocketProvider from './Components/HOC/SocketProvider';
+import GeneralModal from './Components/GeneralModal';
 
 import configureStore from './configureStore';
 import './global.css';
@@ -34,10 +35,12 @@ const App = () => (
           <div
             style={{ display: 'flex', flexFlow: 'column', minHeight: '100vh' }}
           >
-            <Switch>
-              <Route path="/myVMT" component={MyVmt} />
-              <Route path="/" component={Home} />
-            </Switch>
+            <GeneralModal>
+              <Switch>
+                <Route path="/myVMT" component={MyVmt} />
+                <Route path="/" component={Home} />
+              </Switch>
+            </GeneralModal>
           </div>
         </Router>
       </QueryClientProvider>

--- a/client/src/Components/GeneralModal.js
+++ b/client/src/Components/GeneralModal.js
@@ -1,0 +1,49 @@
+import React, { createContext, useState } from 'react';
+import BigModal from './UI/Modal/BigModal';
+import Modal from './UI/Modal/Modal';
+
+export const ModalContext = createContext({
+  show: () => {},
+  showBig: () => {},
+  hide: () => {},
+});
+
+// eslint-disable-next-line react/prop-types
+export default function GeneralModal({ children }) {
+  const [show, setShow] = useState(false);
+  const [child, setChild] = useState(null);
+  const [options, setOptions] = useState({});
+  const [isBig, setIsBig] = useState(false);
+
+  // @TODO Ugh...this function should take a 'type' as parameter, whether Modal or BigModal, and the return/render below should create a component of that type.
+  // Unfortunately, I couldn't get that more extensible approach to work in the short time I tried.
+  const _show = (makeBig) => {
+    return (component, newOptions) => {
+      setChild(component);
+      setShow(true);
+      setIsBig(makeBig);
+      if (newOptions) setOptions(newOptions);
+    };
+  };
+
+  return (
+    <ModalContext.Provider
+      value={{
+        show: _show(false),
+        showBig: _show(true),
+        hide: () => setShow(false),
+      }}
+    >
+      {isBig ? (
+        <BigModal show={show} closeModal={() => setShow(false)} {...options}>
+          {child}
+        </BigModal>
+      ) : (
+        <Modal show={show} closeModal={() => setShow(false)} {...options}>
+          {child}
+        </Modal>
+      )}
+      {children}
+    </ModalContext.Provider>
+  );
+}

--- a/client/src/Components/GeneralModal.js
+++ b/client/src/Components/GeneralModal.js
@@ -18,11 +18,11 @@ export default function GeneralModal({ children }) {
   // @TODO Ugh...this function should take a 'type' as parameter, whether Modal or BigModal, and the return/render below should create a component of that type.
   // Unfortunately, I couldn't get that more extensible approach to work in the short time I tried.
   const _show = (makeBig) => {
-    return (component, newOptions) => {
+    return (component, newOptions = {}) => {
       setChild(component);
       setShow(true);
       setIsBig(makeBig);
-      if (newOptions) setOptions(newOptions);
+      setOptions(newOptions);
     };
   };
 

--- a/client/src/Components/index.js
+++ b/client/src/Components/index.js
@@ -47,3 +47,4 @@ export { default as Iframe } from './Iframe/Iframe';
 export { default as ToolTip } from './ToolTip/ToolTip';
 export { default as Loading } from './Loading/Loading';
 export { default as InfoBox } from './InfoBox/InfoBox';
+export { ModalContext } from './GeneralModal';

--- a/client/src/Containers/Create/MakeRooms/MakeRooms.js
+++ b/client/src/Containers/Create/MakeRooms/MakeRooms.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
@@ -8,6 +8,7 @@ import COLOR_MAP from 'utils/colorMap';
 import AssignmentMatrix from './AssignmentMatrix';
 import AssignRooms from './AssignRooms';
 import AddParticipants from './AddParticipants';
+import { useAppModal } from 'utils';
 
 const MakeRooms = (props) => {
   const {
@@ -26,9 +27,9 @@ const MakeRooms = (props) => {
   const [participants, setParticipants] = useState(initialParticipants);
   const [roomDrafts, setRoomDrafts] = useState([]);
   const [showModal, setShowModal] = useState(false);
-  const [showWarning, setShowWarning] = useState(false);
   const submitArgs = React.useRef(); // used for passing along submit info
   const membersToInviteToCourse = React.useRef(null);
+  const { show: showTheWarning, hide: hideTheWarning } = useAppModal();
 
   // NOTE: These two useEffects react when props change. That's the correct way of checking and responding to
   // changed props.  However, the correct way of detecting and responding to a changed state is to act when the
@@ -228,7 +229,7 @@ const MakeRooms = (props) => {
           )
         )
     );
-    return everyoneAssigned ? submit(submitInfo) : setShowWarning(true);
+    return everyoneAssigned ? submit(submitInfo) : showWarning();
   };
 
   const submit = ({ aliasMode, dueDate, roomName }) => {
@@ -318,6 +319,31 @@ const MakeRooms = (props) => {
     />
   );
 
+  const showWarning = () => {
+    showTheWarning(
+      <Fragment>
+        <div>
+          There are unassigned participants. Do you want to continue with this
+          assignment?
+        </div>
+        <div>
+          <Button
+            m={10}
+            click={() => {
+              submit(submitArgs.current);
+              hideTheWarning();
+            }}
+          >
+            Assign
+          </Button>
+          <Button m={10} theme="Cancel" click={hideTheWarning}>
+            Cancel
+          </Button>
+        </div>
+      </Fragment>
+    );
+  };
+
   return (
     <React.Fragment>
       {showModal && (
@@ -337,22 +363,6 @@ const MakeRooms = (props) => {
             updateMembersToInvite={handleMembersToInvite}
           />
         </BigModal>
-      )}
-      {showWarning && (
-        <Modal show={showWarning} closeModal={() => setShowWarning(false)}>
-          <div>
-            There are unassigned participants. Do you want to continue with this
-            assignment?
-          </div>
-          <div>
-            <Button m={10} click={() => submit(submitArgs.current)}>
-              Assign
-            </Button>
-            <Button m={10} theme="Cancel" click={() => setShowWarning(false)}>
-              Cancel
-            </Button>
-          </div>
-        </Modal>
       )}
       <AssignRooms
         initialAliasMode={selectedAssignment.aliasMode || false}

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -1,10 +1,11 @@
 /* eslint-disable prettier/prettier */
-import React from 'react';
+import React, { useContext } from 'react';
 import html2canvas from 'html2canvas';
 import { debounce } from 'lodash';
 import { useQuery } from 'react-query';
 import API from 'utils/apiRequests';
 import buildLog from 'utils/buildLog';
+import { ModalContext } from 'Components';
 
 const timeFrameFcns = {
   all: () => true,
@@ -320,4 +321,24 @@ export function usePopulatedRooms(
         }),
     options
   );
+}
+
+/**
+ * Hook to an app-level modal that can be called from anywhere.
+ * @param {Component} Element - the React component to put inside the modal
+ * @param {Object} [options = {}] - props to apply to the containing modal
+ * @returns { Object } {
+ *    show - function to show the modal
+ *    hide - function to hide the modal
+ *}
+ */
+
+export function useAppModal() {
+  const modalContext = useContext(ModalContext);
+
+  return {
+    show: modalContext.show,
+    showBig: modalContext.showBig,
+    hide: modalContext.hide,
+  };
 }

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -325,12 +325,12 @@ export function usePopulatedRooms(
 
 /**
  * Hook to an app-level modal that can be called from anywhere.
- * @param {Component} Element - the React component to put inside the modal
- * @param {Object} [options = {}] - props to apply to the containing modal
- * @returns { Object } {
- *    show - function to show the modal
- *    hide - function to hide the modal
- *}
+ * @returns { Object }
+ * {
+ *    show - function to show the modal. Takes a component (e.g., JSX) and a set of options that get handed to the Modal
+ *    showBig - same as show, except renders the component inside of a BigModal
+ *    hide - function to hide the modal/bigModal
+ * }
  */
 
 export function useAppModal() {


### PR DESCRIPTION
This PR addresses the long-standing issue of how we deal with modals.
Previously, we had to create somewhat hacky, bespoke modals on a case-by-case basis.
Now, we are able to use an app-level modal that can be consumed in standard way throughout the app.

Currently, this app-level modal is unused. The intention is to transition any current and future modals to use this.