### PR TITLE
Tooltip Container overflow:hidden cut off the room lobby enter button

### DIFF
--- a/client/src/Components/ToolTip/toolTip.css
+++ b/client/src/Components/ToolTip/toolTip.css
@@ -3,7 +3,7 @@
 }
 
 .Container {
-  overflow: hidden;
+  /* overflow: hidden; */
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
This PR allows the entire enter button to be shown