### PR TITLE
ContentBox and ResourceList minWidth allows space for each custom icon

### DIFF
--- a/client/src/Components/UI/ContentBox/contentBox.css
+++ b/client/src/Components/UI/ContentBox/contentBox.css
@@ -8,7 +8,7 @@
 
 .Container {
   width: 100%;
-  min-width: 447px;
+  min-width: 540px;
   position: relative;
   display: flex;
   padding: 5px;

--- a/client/src/Layout/Dashboard/MainContent/resourceList.css
+++ b/client/src/Layout/Dashboard/MainContent/resourceList.css
@@ -26,6 +26,7 @@
   flex-flow: column;
   flex: 1;
   margin-bottom: 2rem;
+  min-width: 552px;
 }
 
 .Col:first-child {


### PR DESCRIPTION
Preview, Replayer, and Expand icons were getting cut off on smaller screens. 
This PR addresses that by adding a minWidth to ResourceList Container and Column. 