### PR TITLE
Give ContentBox Container a maxWidth

### DIFF
--- a/client/src/Components/UI/ContentBox/contentBox.css
+++ b/client/src/Components/UI/ContentBox/contentBox.css
@@ -20,6 +20,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 600px;
 }
 
 .SubContainer {


### PR DESCRIPTION
This prevents facilitator ContentBox from spilling over into participant ContentBox's space.  