### PR TITLE
Allow archive to handle repeated members

### DIFF
--- a/client/src/Layout/SelectableBoxList/SelectableBoxList.js
+++ b/client/src/Layout/SelectableBoxList/SelectableBoxList.js
@@ -109,7 +109,11 @@ const SelectableBoxList = (props) => {
                   .filter((member) => member.role === 'facilitator')
                   .map(
                     (member, x, arr) =>
-                      `${member.user.username}${x < arr.length - 1 ? ', ' : ''}`
+                      `${
+                        member.user
+                          ? member.user.username
+                          : 'Username not found'
+                      }${x < arr.length - 1 ? ', ' : ''}`
                   )
               : [],
             sinceUpdated: timeDiff(item.updatedAt),

--- a/server/controllers/RoomController.js
+++ b/server/controllers/RoomController.js
@@ -866,6 +866,7 @@ module.exports = {
           instructions: 1,
           description: 1,
           'members.role': 1,
+          'members.user': 1,
           'userObject.username': 1,
           'userObject._id': 1,
           messagesCount: { $size: '$chat' },
@@ -905,7 +906,10 @@ module.exports = {
       if (room.members && room.userObject) {
         room.members.forEach(
           // eslint-disable-next-line no-return-assign
-          (member, idx) => (member.user = room.userObject[idx])
+          (member) =>
+            (member.user = room.userObject.find(
+              (user) => user._id.toString() === member.user.toString()
+            ))
         );
       }
       delete room.userObject;


### PR DESCRIPTION
On occasion, a room might have duplicate members (this is a legacy bug that shouldn't be able to happen anymore because of changes to the interface). This PR allows a more graceful way of handling this ill-formed room on the Archive page.