### PR TITLE
Giv SelectableContentBox container the same css as ContentBox container

### DIFF
--- a/client/src/Components/UI/ContentBox/SelectableContentBox.css
+++ b/client/src/Components/UI/ContentBox/SelectableContentBox.css
@@ -7,8 +7,8 @@
 }
 
 .Container {
-  width: 33vw;
-  min-width: 447px;
+  width: 100%;
+  min-width: 540px;
   position: relative;
   display: flex;
   padding: 5px;
@@ -16,9 +16,11 @@
   border: 1px solid #d8d9da;
   box-shadow: lightestShadow;
   transition: all 0.2s;
+  cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 600px;
 }
 
 .SubContainer {


### PR DESCRIPTION
This is done to keep SelectableContentBox within its ResourceList column. 
Prior to this PR, SelectableContentBox spilled out of its column. 