### PR TITLE
Preview/Monitor fixes

### DIFF
--- a/client/src/Components/UI/Modal/BigModal.js
+++ b/client/src/Components/UI/Modal/BigModal.js
@@ -13,16 +13,15 @@ import classes from './bigModal.css';
 
 const BigModal = ({ show, closeModal, message, children, height, testId }) => {
   const mainDiv = React.createRef();
-  React.useEffect(() => mainDiv.current && mainDiv.current.focus());
+  React.useEffect(() => show && mainDiv.current && mainDiv.current.focus());
   return (
-    <div
-      ref={mainDiv}
-      onKeyDown={(e) => e.key === 'Escape' && closeModal && closeModal()}
-      tabIndex="-1"
-      role="button"
-    >
+    <Fragment>
       <Backdrop show={show} />
       <div
+        ref={mainDiv}
+        onKeyDown={(e) => e.key === 'Escape' && closeModal && closeModal()}
+        tabIndex="-1"
+        role="button"
         className={classes.Modal}
         data-testid={testId}
         style={{
@@ -57,7 +56,7 @@ const BigModal = ({ show, closeModal, message, children, height, testId }) => {
           </Fragment>
         )}
       </div>
-    </div>
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
This PR fixes two issues:
1. The preview/monitor screen would scroll to the bottom annoyingly at various times. This should no longer happen.
2. The Course Preview now shows the room tiles in update order (most recent at the top) whenever the user enters the Course Preview. If the user navigates away from the Preview and back again, the most recently updated room tile should be at the top. (Note: If the user navigates away and back really quickly, occasionally the tiles won't update. This should be a rare edge case related to how quickly the client receives updated room information from the server.)