### PR TITLE
Load desmosLink into activity tabs during login

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -74,7 +74,7 @@ const login = async (req, res) => {
       })
       .populate({
         path: 'activities',
-        populate: { path: 'tabs', select: 'tabType name' },
+        populate: { path: 'tabs', select: 'tabType desmosLink name' },
       })
       .populate({
         path: 'notifications',


### PR DESCRIPTION
This is an attempt to fix a bug that prevents Desmos Activities from referencing their teacher.desmos genesis. 