### PR TITLE
Hide the Room Members tab for participants if aliasing is on

### DIFF
--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -46,13 +46,13 @@ class Room extends Component {
   initialTabs = [{ name: 'Details' }, { name: 'Members' }];
   constructor(props) {
     super(props);
-    const { room } = this.props;
+    const { room, user } = this.props;
     this.state = {
       // member: false,
       guestMode: true,
       tabs: [
         { name: 'Details' },
-        { name: 'Members' },
+        ...(this.shouldShowMembers(room, user) ? [{ name: 'Members' }] : []),
         { name: 'Preview' },
         { name: 'Stats' },
         { name: 'Settings' },
@@ -189,6 +189,10 @@ class Room extends Component {
       });
     }
   }
+
+  shouldShowMembers = (room, user) => {
+    return false;
+  };
 
   enterWithCode = (entryCode) => {
     const { room, user, connectJoinWithCode } = this.props;

--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -201,9 +201,8 @@ class Room extends Component {
 
   isUserFacilitator = () => {
     const { room, user } = this.props;
-    const roomMembers = room.members;
-    const mem = roomMembers.find((member) => member.user._id === user._id);
-    return mem.role === 'facilitator';
+    const mem = room.members.find((member) => member.user._id === user._id);
+    return mem && mem.role ? mem.role === 'facilitator' : false;
   };
 
   enterWithCode = (entryCode) => {

--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -52,7 +52,7 @@ class Room extends Component {
       guestMode: true,
       tabs: [
         { name: 'Details' },
-        ...(this.shouldShowMembers(room, user) ? [{ name: 'Members' }] : []),
+        ...(this.shouldShowMembers() ? [{ name: 'Members' }] : []),
         { name: 'Preview' },
         { name: 'Stats' },
         { name: 'Settings' },
@@ -190,8 +190,25 @@ class Room extends Component {
     }
   }
 
-  shouldShowMembers = (room, user) => {
-    return false;
+  // Don't display Members tab if:
+  // aliased usernames are turned on and user is a facilitator
+  shouldShowMembers = () => {
+    const { room } = this.props;
+    const isFacilitator = this.isUserFacilitator();
+    if (!isFacilitator && room.settings.displayAliasedUsernames) return false;
+    return true;
+  };
+
+  isUserFacilitator = () => {
+    const { room, user } = this.props;
+    const roomMembers = room.members;
+    let isFacilitator = false;
+
+    roomMembers.forEach((member) => {
+      if (member.user._id === user._id && member.role === 'facilitator')
+        isFacilitator = true;
+    });
+    return isFacilitator;
   };
 
   enterWithCode = (entryCode) => {
@@ -771,7 +788,7 @@ Room.propTypes = {
     entryCode: PropTypes.string,
     image: PropTypes.string,
     instructions: PropTypes.string,
-    settings: PropTypes.shape({}),
+    settings: PropTypes.shape({ displayAliasedUsernames: PropTypes.bool }),
   }),
   user: PropTypes.shape({
     _id: PropTypes.string,

--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -202,13 +202,8 @@ class Room extends Component {
   isUserFacilitator = () => {
     const { room, user } = this.props;
     const roomMembers = room.members;
-    let isFacilitator = false;
-
-    roomMembers.forEach((member) => {
-      if (member.user._id === user._id && member.role === 'facilitator')
-        isFacilitator = true;
-    });
-    return isFacilitator;
+    const mem = roomMembers.find((member) => member.user._id === user._id);
+    return mem.role === 'facilitator';
   };
 
   enterWithCode = (entryCode) => {


### PR DESCRIPTION
This PR helps to ensure anonymity in a room with aliased usernames by hiding the Members tab for non-facilitators in that room.