### PR TITLE
When you become a facilitator, create a "Template". It used to be "Activity"

### DIFF
--- a/client/src/Layout/Facilitator/Facilitator.js
+++ b/client/src/Layout/Facilitator/Facilitator.js
@@ -48,7 +48,7 @@ class FacilitatorIntro extends Component {
           </h2>
           <div className={classes.Cards}>
             <div className={classes.CardContainer}>
-              <div className={classes.CreateTitle}>Activity</div>
+              <div className={classes.CreateTitle}>Template</div>
               <NewResource resource="activities" intro />
             </div>
             <div className={classes.CardContainer}>


### PR DESCRIPTION
This PR helps unify the change from "Activity" to "Template" and is shown to a user when they choose to become a facilitator. 