### PR TITLE
Don't update the room timestamp when archiving and unarchiving

### DIFF
--- a/client/src/Components/UI/ContentBox/ContentBox.js
+++ b/client/src/Components/UI/ContentBox/ContentBox.js
@@ -125,7 +125,7 @@ class ContentBox extends PureComponent {
                 </div>
               ) : null}
               {details.sinceUpdated ? (
-                <div>Updated: {details.sinceUpdated} ago</div>
+                <div>Updated: {details.sinceUpdated}</div>
               ) : null}
               {details.createdAt ? (
                 <div>Created: {details.createdAt}</div>

--- a/client/src/Components/UI/ContentBox/SelectableContentBox.js
+++ b/client/src/Components/UI/ContentBox/SelectableContentBox.js
@@ -144,7 +144,7 @@ const SelectableContentBox = (props) => {
                   </div>
                 ) : null}
                 {details.sinceUpdated ? (
-                  <div>Updated: {details.sinceUpdated} ago</div>
+                  <div>Updated: {details.sinceUpdated}</div>
                 ) : null}
                 {details.createdAt ? (
                   <div>Created: {details.createdAt}</div>

--- a/client/src/Layout/BoxList/BoxList.js
+++ b/client/src/Layout/BoxList/BoxList.js
@@ -22,6 +22,7 @@ const boxList = (props) => {
   } = props;
 
   const timeDiff = (ts) => {
+    if (!ts) return 'Never';
     const diff = new Date() - new Date(ts);
     const seconds = Math.floor(diff / 1000);
     const minutes = Math.floor(diff / 60000);
@@ -29,15 +30,15 @@ const boxList = (props) => {
     const days = Math.floor(diff / 86400000);
 
     if (seconds < 60) {
-      return `${seconds} second${seconds > 1 ? 's' : ''}`;
+      return `${seconds} second${seconds > 1 ? 's' : ''} ago`;
     }
     if (minutes < 60) {
-      return `${minutes} minute${minutes > 1 ? 's' : ''}`;
+      return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
     }
     if (hours < 60) {
-      return `${hours} hour${hours > 1 ? 's' : ''}`;
+      return `${hours} hour${hours > 1 ? 's' : ''} ago`;
     }
-    return `${days} day${days > 1 ? 's' : ''}`;
+    return `${days} day${days > 1 ? 's' : ''} ago`;
   };
 
   let listElems = "There doesn't appear to be anything here yet";

--- a/client/src/Layout/SelectableBoxList/SelectableBoxList.js
+++ b/client/src/Layout/SelectableBoxList/SelectableBoxList.js
@@ -45,6 +45,7 @@ const SelectableBoxList = (props) => {
   };
 
   const timeDiff = (ts) => {
+    if (!ts) return 'Never';
     const diff = new Date() - new Date(ts);
     const seconds = Math.floor(diff / 1000);
     const minutes = Math.floor(diff / 60000);
@@ -52,15 +53,15 @@ const SelectableBoxList = (props) => {
     const days = Math.floor(diff / 86400000);
 
     if (seconds < 60) {
-      return `${seconds} second${seconds > 1 ? 's' : ''}`;
+      return `${seconds} second${seconds > 1 ? 's' : ''} ago`;
     }
     if (minutes < 60) {
-      return `${minutes} minute${minutes > 1 ? 's' : ''}`;
+      return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
     }
     if (hours < 60) {
-      return `${hours} hour${hours > 1 ? 's' : ''}`;
+      return `${hours} hour${hours > 1 ? 's' : ''} ago`;
     }
-    return `${days} day${days > 1 ? 's' : ''}`;
+    return `${days} day${days > 1 ? 's' : ''} ago`;
   };
 
   const listElems = "There doesn't appear to be anything here yet";

--- a/server/controllers/RoomController.js
+++ b/server/controllers/RoomController.js
@@ -550,13 +550,18 @@ module.exports = {
         removeAndChangeStatus(id, STATUS.ARCHIVED, reject, resolve);
       } else {
         // unarchive is flag is set
+        let willUnarchive = false;
         if (body.unarchive) {
           delete body.unarchive;
           unarchive(id);
+          willUnarchive = true;
         }
         const doUpdateTabVisitors =
           typeof body.instructions === 'string' && body.instructions.length > 0;
-        db.Room.findByIdAndUpdate(id, body, { new: true })
+        db.Room.findByIdAndUpdate(id, body, {
+          new: true,
+          timestamps: !willUnarchive,
+        })
           .populate('currentMembers.user members.user', 'username')
           .populate('chat') // this seems random
           .then((res) => {
@@ -935,7 +940,7 @@ const removeAndChangeStatus = (id, status, reject, resolve) => {
     .then(async (room) => {
       room.status = status;
       try {
-        updatedRoom = await room.save();
+        updatedRoom = await room.save({ timestamps: false });
       } catch (err) {
         reject(err);
       }


### PR DESCRIPTION
This PR will allow archived rooms to be searched by their last true update timestamp (i.e., the timestamp of the last event).