### PR TITLE
Don't display grouping (in reuse or edit assignments) if grouping has one or more deleted rooms

### DIFF
--- a/client/src/utils/groupings.js
+++ b/client/src/utils/groupings.js
@@ -53,7 +53,7 @@ export const createPreviousAssignments = (groupings) => {
     grouping.rooms.every(
       (roomId) =>
         rooms[roomId] &&
-        rooms[roomId].status !== STATUS.ARCHIVED &&
+        rooms[roomId].status === STATUS.DEFAULT &&
         !userAchivedRooms.includes(roomId)
     )
   );


### PR DESCRIPTION
This PR address an error specifically regarding reusing a grouping with a deleted room. 
Previously, if you clicked to reuse a grouping with a deleted room the app would crash because the necessary room data could not be found.
Now, groupings with deleted rooms are simply filtered out and not shown in the Assign dropdown menu.