### PR TITLE
correct way of doing pi versioning

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "3.1.4.1592",
+  "version": "3.1.4-1592",
   "private": true,
   "dependencies": {
     "@xstate/react": "^3.0.1",


### PR DESCRIPTION
It turns out that "3.1.4-1592" is fine but "3.1.4.1592" is not (on staging)