### PR TITLE
Limit the amount of ids passed to server in Monitor & Course Preview

### DIFF
--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -331,12 +331,15 @@ export function usePopulatedRooms(
           currIds,
           shouldBuildLog
         );
-        results.push(...rooms.data.results);
+        results.push(rooms.data.results);
       }
 
+      const resolvedResults = await Promise.all(results);
+      const fullResults = resolvedResults.flat();
+
       const roomArray = !shouldBuildLog
-        ? [...results]
-        : results.map((room) => {
+        ? [...fullResults]
+        : fullResults.map((room) => {
             const log = buildLog(room.tabs, room.chat);
             return { ...room, log };
           });

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -326,17 +326,16 @@ export function usePopulatedRooms(
       // because we were encountering 414 errors
       const CALL_LIMIT = 50;
       const chunkedRoomIds = chunk(roomIds, CALL_LIMIT);
-      const results = chunkedRoomIds.map(async (ids) => {
-        const rooms = await API.findAllMatchingIdsPopulated(
+      const results = chunkedRoomIds.map((ids) => {
+        return API.findAllMatchingIdsPopulated(
           'rooms',
           ids,
           shouldBuildLog
         );
-        return rooms.data.results;
       });
-
+      
       const resolvedResults = await Promise.all(results);
-      const fullResults = resolvedResults.flat();
+      const fullResults = resolvedResults.map((res) => res.data.results).flat()
 
       const roomArray = !shouldBuildLog
         ? [...fullResults]


### PR DESCRIPTION
This PR address a 414 error we encountered by passing too many ids through the request header.
Now, we limit the amount of ids passed to 50.