### PR TITLE
Resource list styling

### DIFF
--- a/client/src/Components/Form/Checkbox/checkbox.css
+++ b/client/src/Components/Form/Checkbox/checkbox.css
@@ -14,7 +14,7 @@
 .checkbox label {
   position: relative;
   display: inline-block;
-
+  width: 100%;
   /*16px width of fake checkbox + 6px distance between fake checkbox and text*/
   padding-left: 22px;
   cursor: pointer;

--- a/client/src/Components/UI/ContentBox/Icons/icons.css
+++ b/client/src/Components/UI/ContentBox/Icons/icons.css
@@ -11,7 +11,7 @@
   display: flex;
   align-items: center;
   height: 25px;
-  /* width: 35px; */
+  width: 35px;
 }
 
 .Globe {

--- a/client/src/Components/UI/ContentBox/SelectableContentBox.css
+++ b/client/src/Components/UI/ContentBox/SelectableContentBox.css
@@ -8,7 +8,7 @@
 
 .Container {
   width: 100%;
-  min-width: 540px;
+  min-width: 32vw;
   position: relative;
   display: flex;
   padding: 5px;

--- a/client/src/Components/UI/ContentBox/SelectableContentBox.js
+++ b/client/src/Components/UI/ContentBox/SelectableContentBox.js
@@ -46,7 +46,7 @@ const SelectableContentBox = (props) => {
   return (
     <Checkbox
       change={onSelect}
-      style={{ margin: '0 1rem 0 0' }}
+      style={{ margin: '0 1rem 0 0', width: '100%' }}
       checked={isChecked}
       dataId={id}
       id={id}

--- a/client/src/Containers/Archive.css
+++ b/client/src/Containers/Archive.css
@@ -1,10 +1,11 @@
 .CustomIcon {
   margin-top: 5px;
   font-size: 20px;
+  font-weight: 500;
 }
 
 .CustomIcon:hover {
   cursor: pointer;
   font-size: 21px;
-  font-weight: 600;
+  font-weight: 900;
 }

--- a/client/src/Containers/Archive.js
+++ b/client/src/Containers/Archive.js
@@ -336,6 +336,7 @@ const Archive = () => {
       setFromDate={setFromDate}
       icons={customIcons}
       selectActions={selectActions}
+      totalNumberOfArchivedRooms={archive.rooms.length}
     />
   );
 };

--- a/client/src/Containers/RoomLobby.css
+++ b/client/src/Containers/RoomLobby.css
@@ -1,11 +1,12 @@
 .CustomIcon {
     margin-top: 5px;
     font-size: 24px;
+    font-weight: 500;
   }
   
   .CustomIcon:hover {
     cursor: pointer;
-    font-weight: 600;
+    font-weight: 900;
     font-size: 25px;
   }
   

--- a/client/src/Layout/Archive/Archive.js
+++ b/client/src/Layout/Archive/Archive.js
@@ -32,6 +32,7 @@ const Archive = (props) => {
     icons,
     selectActions,
     actionComponent,
+    totalNumberOfArchivedRooms,
   } = props;
 
   const toggleRoomFilter = (type) => toggleFilter(`room-${type}`);
@@ -44,7 +45,7 @@ const Archive = (props) => {
         <div className={classes.Header}>
           <h3 className={classes.Title}>
             {/* Search for your archived Rooms and Courses */}
-            Search for your archived Rooms
+            Search your {totalNumberOfArchivedRooms} archived Rooms
           </h3>
           <div className={classes.ResourceOpts} data-testid="resource-tabs">
             {/* <div
@@ -250,6 +251,7 @@ Archive.propTypes = {
   icons: PropTypes.arrayOf(PropTypes.shape({})),
   selectActions: PropTypes.arrayOf(PropTypes.shape({})),
   actionComponent: PropTypes.node,
+  totalNumberOfArchivedRooms: PropTypes.number.isRequired,
 };
 
 Archive.defaultProps = {

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -147,15 +147,13 @@ const ResourceList = ({
       handleArchive(id);
     },
     icon: (
-      <ToolTip text="Archive" delay={600}>
-        <span
-          className={`material-symbols-outlined ${classes.CustomIcon}`}
-          data-testid="Archive"
-          style={{ fontSize: '23px' }}
-        >
-          input
-        </span>
-      </ToolTip>
+      <span
+        className={`material-symbols-outlined ${classes.CustomIcon}`}
+        data-testid="Archive"
+        style={{ fontSize: '23px' }}
+      >
+        input
+      </span>
     ),
   };
 

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -314,7 +314,7 @@ const ResourceList = ({
           <div className={classes.Row}>
             <div className={classes.Col}>
               <h2 className={classes.ResourceHeader}>
-                {displayResource} I Manage
+                {displayResource} I Manage: {fList.length}
               </h2>
               {fList.length >= 1 && setResourceState && (
                 <SortUI
@@ -352,7 +352,7 @@ const ResourceList = ({
             </div>
             <div className={classes.Col}>
               <h2 className={classes.ResourceHeader}>
-                {displayResource} I&#39;m a member of
+                {displayResource} I&#39;m a member of: {pList.length}
               </h2>
               {pList.length >= 1 && setResourceState && (
                 <SortUI

--- a/client/src/Layout/Dashboard/MainContent/resourceList.css
+++ b/client/src/Layout/Dashboard/MainContent/resourceList.css
@@ -73,10 +73,11 @@
 .CustomIcon {
   margin-top: 5px;
   font-size: 20px;
+  font-weight: 500;
 }
 
 .CustomIcon:hover {
   cursor: pointer;
   font-size: 21px;
-  font-weight: 600;
+  font-weight: 900;
 }

--- a/client/src/Layout/SelectableBoxList/SelectableBoxList.css
+++ b/client/src/Layout/SelectableBoxList/SelectableBoxList.css
@@ -30,9 +30,7 @@
 }
 
 .ContentBox {
-  width: 36vw;
-  /* min-width: 497px; */
-  /* max-width: 33vw; */
+  width: 100%;
   margin: 2px 2px 2px 0;
   transition: 0.2s;
 }


### PR DESCRIPTION
- Display number of resources for user lists (not in Community / Dashboard)
- Display total number of archived rooms on Archive page
- Fix privacy/roomType icon misalignment by giving Icon a set width
- Fix SelectableContentBox extending beyond it's boundary (e.g. extending into "Rooms I'm a Member of")
- Give custom icons (preview, archive, etc.) a set font-weight to account for different browsers. Safari, for example, defaulted the font-weight to be too small which made the icons look too insignificant.
