### PR TITLE
Undo min-width to keep selectable content box contained within its column

### DIFF
--- a/client/src/Components/UI/ContentBox/SelectableContentBox.css
+++ b/client/src/Components/UI/ContentBox/SelectableContentBox.css
@@ -8,7 +8,7 @@
 
 .Container {
   width: 100%;
-  min-width: 32vw;
+  /* min-width: 32vw; */
   position: relative;
   display: flex;
   padding: 5px;


### PR DESCRIPTION
min-width of 32vw made the selectable content box too large on certain screen widths