### PR TITLE
Add remainders to rooms numerically, starting with room 1

### DIFF
--- a/client/src/Containers/Create/MakeRooms/MakeRooms.js
+++ b/client/src/Containers/Create/MakeRooms/MakeRooms.js
@@ -148,9 +148,8 @@ const MakeRooms = (props) => {
     }
 
     // assign any extra participants to other rooms
-    participantsToAssign.forEach((participant) => {
-      const roomNum = Math.floor(Math.random() * roomsUpdate.length);
-      roomsUpdate[roomNum].members.push(participant);
+    participantsToAssign.forEach((participant, roomNum) => {
+      roomsUpdate[roomNum % roomsUpdate.length].members.push(participant);
     });
 
     setRoomDrafts(roomsUpdate);


### PR DESCRIPTION
Previously, remainders were added to random rooms which was unclear and made it possible for >1 remainder participant to end up in the same room.