### PR TITLE
Archive course rooms

### DIFF
--- a/client/src/Containers/Course.js
+++ b/client/src/Containers/Course.js
@@ -409,6 +409,7 @@ class Course extends Component {
             parentResource="courses"
             parentResourceId={course._id}
             context="course"
+            selectableBoxList
           />
         );
       } else if (resource === 'members') {

--- a/client/src/Containers/Course.js
+++ b/client/src/Containers/Course.js
@@ -372,19 +372,19 @@ class Course extends Component {
     } = this.state;
     if (course && !guestMode) {
       const { resource } = match.params;
-      let myRooms;
-      if (resource === 'rooms') {
-        // allow course facilitators to see all rooms
-        if (course.myRole !== 'facilitator') {
-          myRooms = course.rooms.filter((room) => {
-            let included = false;
-            room.members.forEach((member) => {
-              if (member.user._id === user._id) included = true;
-            });
-            return included;
-          });
-        }
-      }
+      // let myRooms;
+      // if (resource === 'rooms') {
+      //   // allow course facilitators to see all rooms
+      //   if (course.myRole !== 'facilitator') {
+      //     myRooms = course.rooms.filter((room) => {
+      //       let included = false;
+      //       room.members.forEach((member) => {
+      //         if (member.user._id === user._id) included = true;
+      //       });
+      //       return included;
+      //     });
+      //   }
+      // }
       // let contentData = {
       //   resource,
       //   parentResource: "courses",
@@ -400,7 +400,8 @@ class Course extends Component {
       if (resource === 'rooms' || resource === 'activities') {
         mainContent = (
           <DashboardContent
-            userResources={myRooms || course[resource] || []}
+            // userResources={myRooms || course[resource] || []}
+            userResources={course[resource] || []}
             user={user}
             resource={resource}
             notifications={notifications.filter(
@@ -721,14 +722,14 @@ Course.defaultProps = {
   notifications: null,
 };
 
-const combineResources = (resources) => {
-  // ensure no repeated resources
-  const obj = resources.reduce((acc, res) => {
-    acc[res._id] = res;
-    return acc;
-  }, {});
-  return [...Object.values(obj)];
-};
+// const combineResources = (resources) => {
+//   // ensure no repeated resources
+//   const obj = resources.reduce((acc, res) => {
+//     acc[res._id] = res;
+//     return acc;
+//   }, {});
+//   return [...Object.values(obj)];
+// };
 const mapStateToProps = (store, ownProps) => {
   // eslint-disable-next-line camelcase
   const { course_id } = ownProps.match.params;
@@ -738,20 +739,21 @@ const mapStateToProps = (store, ownProps) => {
   // Ownprops.course is the course from the db given by withPopulatedCourse. It has all the activities and rooms in the course; the localCourse
   // only has the resources that the user has access to.
   return {
-    course:
-      localCourse && localCourse.myRole === 'facilitator'
-        ? {
-            ...localCourse,
-            activities: combineResources([
-              ...ownProps.course.activities,
-              ...localCourse.activities,
-            ]),
-            rooms: combineResources([
-              ...ownProps.course.rooms,
-              ...localCourse.rooms,
-            ]),
-          }
-        : localCourse,
+    // course:
+    //   localCourse && localCourse.myRole === 'facilitator'
+    //     ? {
+    //         ...localCourse,
+    //         activities: combineResources([
+    //           ...ownProps.course.activities,
+    //           ...localCourse.activities,
+    //         ]),
+    //         rooms: combineResources([
+    //           ...ownProps.course.rooms,
+    //           ...localCourse.rooms,
+    //         ]),
+    //       }
+    //     : localCourse,
+    course: localCourse,
     activities: store.activities.allIds, // @TODO: Note that this prop is never used. It is all activities user has access to.
     rooms: store.rooms.allIds,
     user: store.user,

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -152,13 +152,15 @@ const ResourceList = ({
       handleArchive(id);
     },
     icon: (
-      <span
-        className={`material-symbols-outlined ${classes.CustomIcon}`}
-        data-testid="Archive"
-        style={{ fontSize: '23px' }}
-      >
-        input
-      </span>
+      <ToolTip text="Archive" delay={600}>
+        <span
+          className={`material-symbols-outlined ${classes.CustomIcon}`}
+          data-testid="Archive"
+          style={{ fontSize: '23px' }}
+        >
+          input
+        </span>
+      </ToolTip>
     ),
   };
 

--- a/client/src/Routes/MyVmt.js
+++ b/client/src/Routes/MyVmt.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import {
-  withControlMachine,
-  withPopulatedCourse,
-  withPopulatedActivity,
-} from 'utils';
+import { withControlMachine, withPopulatedActivity } from 'utils';
 import Navbar from '../Components/Navigation/Navbar';
 import {
   MyVMT,
@@ -33,7 +29,7 @@ const pages = [
   { path: '/:resource', component: MyVMT },
   {
     path: '/courses/:course_id/:resource',
-    component: withPopulatedCourse(Course), // provide the course from the DB to allow facilitators to see all resources
+    component: Course,
     redirectPath: '/classcode',
   },
   {


### PR DESCRIPTION
Add the ability to archive rooms from the Course lobby.

This pr includes changes to how a course is loaded. Previously, we used withPopulatedCourse to allow facilitators to see all of the course's resources. This hindered a course's ability to live update the rooms list after archiving. Since facilitators now have access to all course resources by default, we can confidently live-load the course from the redux store, which accurately reflects archiving. 
This is a rather big change and will need to be monitored on staging.