### PR TITLE
Remove room from course & activity if needed when archiving multiple rooms at once

### DIFF
--- a/client/src/store/actions/rooms.js
+++ b/client/src/store/actions/rooms.js
@@ -397,8 +397,17 @@ export const updateRoom = (id, body) => {
 };
 
 export const archiveRooms = (ids) => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     ids.forEach((id) => {
+      // remove room from course & activity (template) if needed
+      const room = { ...getState().rooms.byId[id] };
+      if (room.course) {
+        dispatch(removeCourseRoom(room.course, id));
+      }
+      if (room.activity) {
+        dispatch(removeActivityRoom(room.activity, id));
+      }
+
       dispatch(addRoomToArchive(id));
       dispatch(removeUserRooms([id]));
       dispatch(roomsRemoved([id]));


### PR DESCRIPTION
This pr addresses an issue that created a temporary blank room when archiving multiple rooms at once from within a Course or Template rooms list. 