### PR TITLE
Refactor of Tabs in a math space

### DIFF
--- a/client/src/Containers/Replayer/SharedReplayer.js
+++ b/client/src/Containers/Replayer/SharedReplayer.js
@@ -558,16 +558,7 @@ class SharedReplayer extends Component {
           graphs={graphs}
           // user={user}
           chat={this.updatedLog.length > 0 ? chat : null}
-          tabs={
-            <Tabs
-              tabs={populatedRoom.tabs}
-              changeTabs={this.changeTab}
-              currentTabId={currentTabId}
-              participantCanCreate={false}
-              replayer
-              memberRole="participant" // this controls the user's ability to make a new tab...we don't want them to make a new a tab in the replayer no matter what their role is
-            />
-          }
+          tabs={<Tabs tabs={populatedRoom.tabs} currentTabId={currentTabId} />}
           currentMembers={
             currentMembers.length > 0 ? (
               <CurrentMembers

--- a/client/src/Containers/Workspace/ActivityWorkspace.js
+++ b/client/src/Containers/Workspace/ActivityWorkspace.js
@@ -7,8 +7,10 @@ import {
   updateActivityTab,
   setActivityStartingPoint,
   getCurrentActivity,
-} from '../../store/actions';
-import { Modal, Loading } from '../../Components';
+} from 'store/actions';
+import { Modal, Loading } from 'Components';
+import { WorkspaceLayout } from 'Layout';
+import { ROLE } from 'constants.js';
 import {
   DesmosActivityGraph,
   DesmosActivityEditor,
@@ -18,7 +20,6 @@ import {
   RoomInfo,
   ActivityTools,
 } from './index';
-import { WorkspaceLayout } from '../../Layout';
 import NewTabForm from '../Create/NewTabForm';
 import CreationModal from './Tools/CreationModal';
 
@@ -169,13 +170,11 @@ class ActivityWorkspace extends Component {
       });
       tabs = (
         <Tabs
-          activity
           tabs={activity.tabs}
           currentTabId={currentTabId || initialTabId}
-          participantCanCreate={false}
-          memberRole={role}
-          changeTab={this.changeTab}
-          createNewTab={this.createNewTab}
+          canCreate={role === ROLE.FACILITATOR}
+          onChangeTab={this.changeTab}
+          onCreateNewTab={this.createNewTab}
         />
       );
     }

--- a/client/src/Containers/Workspace/DesmosActivity.js
+++ b/client/src/Containers/Workspace/DesmosActivity.js
@@ -87,15 +87,17 @@ const DesmosActivity = (props) => {
   // listener and event state handlers
   // Persistent Events
   useEffect(() => {
+    const { inControl } = props;
     const type = 'persistent';
-    if (props.inControl === 'ME') {
+    if (inControl === 'ME') {
       handleResponseData(activityUpdates, type);
     }
   }, [activityUpdates]);
   // Transient Events including page changes
   useEffect(() => {
+    const { inControl } = props;
     const type = 'transient';
-    if (props.inControl === 'ME') {
+    if (inControl === 'ME') {
       handleResponseData(transientUpdates, type);
     }
   }, [transientUpdates]);
@@ -136,7 +138,6 @@ const DesmosActivity = (props) => {
     // INITIALIZE EVENT LISTENER
     const { tab, updatedRoom, addNtfToTabs, addToLog, temp } = props;
 
-    socket.removeAllListeners('RECEIVE_EVENT');
     socket.on('RECEIVE_EVENT', (data) => {
       // console.log('Socket: Received data: ', data);
       addToLog(data);
@@ -252,7 +253,7 @@ const DesmosActivity = (props) => {
       'Player instance: ',
       calculatorInst.current
     );
-    props.setFirstTabLoaded();
+    setFirstTabLoaded();
     initializeListeners();
     // Go to screen last used
     if (tab.currentScreen) {
@@ -304,7 +305,8 @@ const DesmosActivity = (props) => {
   }
 
   function _hasControl() {
-    return props.inControl === 'ME';
+    const { inControl } = props;
+    return inControl === 'ME';
   }
 
   // @TODO this could be selectively handled depending what div is clicked
@@ -341,6 +343,7 @@ const DesmosActivity = (props) => {
   const {
     inControl,
     user,
+    toggleControl,
     // @TODO **NONE OF THESE PROPS ARE RECEIVED RIGHT NOW **
     // showRefWarning,
     // refWarningMsg,
@@ -359,7 +362,7 @@ const DesmosActivity = (props) => {
           setShowControlWarning(false);
         }}
         takeControl={() => {
-          props.toggleControl();
+          toggleControl();
           setShowControlWarning(false);
         }}
         inControl={inControl}

--- a/client/src/Containers/Workspace/Tabs.js
+++ b/client/src/Containers/Workspace/Tabs.js
@@ -26,7 +26,7 @@ const Tabs = ({
       <div style={{ zIndex: tabs.length - i }} className={classes.TabBox}>
         <span className={classes.TabName}>{tab.name}</span>
       </div>
-      {ntfTabs.includes(tab._id) ? (
+      {tab._id !== currentTabId && ntfTabs.includes(tab._id) ? (
         <div className={classes.TabNotification}>
           <i className="fas fa-exclamation" />
         </div>

--- a/client/src/Containers/Workspace/Tabs.js
+++ b/client/src/Containers/Workspace/Tabs.js
@@ -1,95 +1,78 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classes from './tabs.css';
 
-class Tabs extends Component {
-  // shouldComponentUpdate(nextProps) {
-  //   if (nextProps.currentTab !== this.props.currentTab) {
-  //     return true;
-  //   } else if (nextProps.tabs.length !== this.props.tabs.length) {
-  //     return true;
-  //   } else if (nextProps.ntfTabs.length !== this.props.ntfTabs.length) {
-  //     return true;
-  //   } else return false;
-  // }
-
-  render() {
-    const {
-      tabs,
-      currentTabId,
-      ntfTabs,
-      memberRole,
-      changeTab,
-      createNewTab,
-      participantCanCreate,
-      replayer,
-    } = this.props;
-    const tabEls = tabs.map((tab, i) => (
-      <div
-        key={tab._id || i}
-        onClick={!replayer ? () => changeTab(tab._id) : null}
-        onKeyPress={!replayer ? () => changeTab(tab._id) : null}
-        role="button"
-        tabIndex="-2"
-        className={[
-          classes.Tab,
-          tab._id === currentTabId ? classes.Active : '',
-        ].join(' ')}
-        style={{ zIndex: tabs.length - i }}
-      >
-        <div style={{ zIndex: tabs.length - i }} className={classes.TabBox}>
-          <span className={classes.TabName}>{tab.name}</span>
+const Tabs = ({
+  tabs,
+  currentTabId,
+  ntfTabs,
+  onChangeTab,
+  onCreateNewTab,
+  canCreate,
+}) => {
+  const tabEls = tabs.map((tab, i) => (
+    <div
+      key={tab._id || i}
+      onClick={() => onChangeTab(tab._id)}
+      onKeyPress={() => onChangeTab(tab._id)}
+      role="button"
+      tabIndex="-2"
+      className={[
+        classes.Tab,
+        tab._id === currentTabId ? classes.Active : '',
+      ].join(' ')}
+      style={{ zIndex: tabs.length - i }}
+    >
+      <div style={{ zIndex: tabs.length - i }} className={classes.TabBox}>
+        <span className={classes.TabName}>{tab.name}</span>
+      </div>
+      {ntfTabs.includes(tab._id) ? (
+        <div className={classes.TabNotification}>
+          <i className="fas fa-exclamation" />
         </div>
-        {ntfTabs && ntfTabs.includes(tab._id) ? (
-          <div className={classes.TabNotification}>
-            <i className="fas fa-exclamation" />
+      ) : null}
+    </div>
+  ));
+  return (
+    <div className={classes.WorkspaceTabs} data-testid="tabs-container">
+      {tabEls}
+      {canCreate ? (
+        <div className={[classes.Tab, classes.NewTab].join(' ')}>
+          <div
+            onClick={onCreateNewTab}
+            onKeyPress={onCreateNewTab}
+            role="button"
+            tabIndex="-3"
+            className={classes.TabBox}
+          >
+            <i data-testid="add-tab" className="fas fa-plus" />
           </div>
-        ) : null}
-      </div>
-    ));
-    return (
-      <div className={classes.WorkspaceTabs} data-testid="tabs-container">
-        {tabEls}
-        {memberRole === 'facilitator' || participantCanCreate ? (
-          <div className={[classes.Tab, classes.NewTab].join(' ')}>
-            <div
-              onClick={createNewTab}
-              onKeyPress={createNewTab}
-              role="button"
-              tabIndex="-3"
-              className={classes.TabBox}
-            >
-              <i data-testid="add-tab" className="fas fa-plus" />
-            </div>
-          </div>
-        ) : null}
-      </div>
-    );
-  }
-}
+        </div>
+      ) : null}
+    </div>
+  );
+};
 
 Tabs.propTypes = {
   tabs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  participantCanCreate: PropTypes.bool.isRequired,
+  canCreate: PropTypes.bool,
   currentTabId: PropTypes.string.isRequired,
   ntfTabs: PropTypes.arrayOf(PropTypes.shape({})),
-  memberRole: PropTypes.string.isRequired,
-  replayer: PropTypes.bool,
-  changeTab: PropTypes.func,
-  createNewTab: (props, propName) => {
-    if (props.participantCanCreate && !props[propName]) {
+  onChangeTab: PropTypes.func,
+  onCreateNewTab: (props, propName) => {
+    if (props.canCreate && !props[propName]) {
       throw new Error(
-        'if participants can create a create function needs to be provided'
+        'if participants can create tabs, a create tab function must be provided'
       );
     }
   },
 };
 
 Tabs.defaultProps = {
-  changeTab: null,
-  replayer: false,
-  createNewTab: null,
+  onChangeTab: () => {},
+  onCreateNewTab: () => {},
   ntfTabs: [],
+  canCreate: false,
 };
 
 export default Tabs;

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -13,20 +13,21 @@ import {
   setRoomStartingPoint,
   updateUser,
   updateUserSettings,
-} from '../../store/actions';
-import mongoIdGenerator from '../../utils/createMongoId';
-import WorkspaceLayout from '../../Layout/Workspace/Workspace';
-import { Chat, Tabs, Tools, RoomInfo } from '.';
-import { Modal, CurrentMembers, Loading, TabTypes } from '../../Components';
-import NewTabForm from '../Create/NewTabForm';
-import CreationModal from './Tools/CreationModal';
+} from 'store/actions';
+import { Modal, CurrentMembers, Loading, TabTypes } from 'Components';
+import { ROLE } from 'constants.js';
 import {
   socket,
   useSnapshots,
   API,
   controlStates,
   controlEvents,
-} from '../../utils';
+  createMongoId as mongoIdGenerator,
+} from 'utils';
+import { WorkspaceLayout } from 'Layout';
+import { Chat, Tabs, Tools, RoomInfo } from '.';
+import NewTabForm from '../Create/NewTabForm';
+import CreationModal from './Tools/CreationModal';
 
 class Workspace extends Component {
   constructor(props) {
@@ -58,7 +59,7 @@ class Workspace extends Component {
       referFromEl: null,
       referFromCoords: null,
       currentTabId: populatedRoom.tabs[0]._id,
-      role: 'participant',
+      role: ROLE.PARTICIPANT,
       creatingNewTab: false,
       activityOnOtherTabs: [],
       chatExpanded: true,
@@ -310,8 +311,8 @@ class Workspace extends Component {
         const { role } = populatedRoom.members.filter(
           (member) => member.user._id === user._id
         )[0];
-        if (role === 'facilitator') {
-          this.setState({ role: 'facilitator' });
+        if (role === ROLE.FACILITATOR) {
+          this.setState({ role });
         }
       } catch (err) {
         if (user.isAdmin) {
@@ -321,7 +322,6 @@ class Workspace extends Component {
       if (!user.inAdminMode) {
         socket.emit('JOIN', sendData, (data, err) => {
           if (err) {
-            // eslint-disable-next-line no-console
             console.log('Error joining room');
             console.log(err);
             this.goBack();
@@ -460,7 +460,7 @@ class Workspace extends Component {
     const { role } = this.state;
     const { populatedRoom } = this.props;
     if (
-      role === 'facilitator' ||
+      role === ROLE.FACILITATOR ||
       populatedRoom.settings.participantsCanCreateTabs
     ) {
       this.setState({ creatingNewTab: true });
@@ -965,13 +965,15 @@ class Workspace extends Component {
     );
     const tabs = (
       <Tabs
-        participantCanCreate={populatedRoom.settings.participantsCanCreateTabs}
+        canCreate={
+          populatedRoom.settings.participantsCanCreateTabs ||
+          role === ROLE.FACILITATOR
+        }
         tabs={currentTabs}
         ntfTabs={activityOnOtherTabs}
         currentTabId={currentTabId}
-        memberRole={role}
-        changeTab={this.changeTab}
-        createNewTab={this.createNewTab}
+        onChangeTab={this.changeTab}
+        onCreateNewTab={this.createNewTab}
       />
     );
     const chat = (


### PR DESCRIPTION
This PR simplifies and fixes the underlying code having to do with participants switching among tabs in a math space. Users might notice fewer syncing issues between tabs (or none, hopefully). Additionally, this PR fixes a bug whereby the notification icon (the spinning explanation point) sometimes appeared in the current tab.