### PR TITLE
New approach to monitor updates

### DIFF
--- a/client/src/Containers/Monitoring/RoomsMonitor.js
+++ b/client/src/Containers/Monitoring/RoomsMonitor.js
@@ -11,6 +11,7 @@ import {
 import Chart from 'Containers/Stats/Chart';
 import statsReducer, { initialState } from 'Containers/Stats/statsReducer';
 import { dateAndTime, useUIState } from 'utils';
+import { debounce, isEqual } from 'lodash';
 import Thumbnails from './Thumbnails';
 import QuickChat from './QuickChat';
 import classes from './monitoringView.css';
@@ -41,6 +42,8 @@ function RoomsMonitor({
   user,
   onThumbnailSelected,
   context, // used for saving and restoring UI state
+  onVisible, // provides array of ids of rooms that are visible on the screen
+  isLoading, // array of ids that are currently loading
 }) {
   const constants = {
     CHAT: 'Chat',
@@ -68,6 +71,50 @@ function RoomsMonitor({
 
   /**
    *
+   * IMPLEMENT OBSERVER LOGIC
+   *
+   */
+
+  const [divRefs, setDivRefs] = React.useState([]);
+
+  const observerRef = React.useRef();
+  const visibilityRef = React.useRef({});
+
+  const onVisibleDebounce = debounce(onVisible, 500);
+
+  React.useEffect(() => {
+    // Create a new array of refs when component mounts
+    const newDivs = Object.keys(populatedRooms).map(() => React.createRef());
+    setDivRefs(newDivs);
+  }, [populatedRooms.length]);
+
+  // Whenever the visibility of divs change, the callback on InsersectionObserver gets called, but ONLY WITH
+  // THE DIVS THAT CHANGED VISIBILITY. We use the visibilityRef to keep track of tje visibility of all the divs that can
+  // be displayed.
+  React.useEffect(() => {
+    // for some reason, vscode doesn't recognize InterserctionObserver
+    // eslint-disable-next-line no-undef
+    observerRef.current = new IntersectionObserver((entries) => {
+      visibilityRef.current = entries.reduce(
+        (acc, entry) => ({ ...acc, [entry.target.id]: entry.isIntersecting }),
+        visibilityRef.current
+      );
+      const visibleDivIds = Object.keys(visibilityRef.current).filter(
+        (key) => visibilityRef.current[key]
+      );
+      onVisibleDebounce(visibleDivIds);
+    });
+    divRefs.forEach((ref) => {
+      if (ref.current) observerRef.current.observe(ref.current);
+    });
+
+    return () => {
+      observerRef.current.disconnect();
+    };
+  }, [divRefs]);
+
+  /**
+   *
    * FUNCTIONS THAT ARE USED TO SIMPLIFY THE RENDER LOGIC
    *
    */
@@ -75,14 +122,11 @@ function RoomsMonitor({
   const _adminWarning = () => {
     return (
       <div style={{ color: 'red' }}>
-        {/* {!user.isAdmin ? (
-          <span>
-            Warning: You are not an Admin. If you enter a room, you will be
-            seen. To become an admin, please contact your VMT administrator.
-          </span>
-        ) : ( */}
         {user.isAdmin && !user.inAdminMode && (
-          <span>Warning: You are not currently in Admin mode.</span>
+          <span>
+            Warning: You are not currently in Admin mode. If you enter a room,
+            you will be seen.
+          </span>
         )}
       </div>
     );
@@ -118,8 +162,6 @@ function RoomsMonitor({
     ];
   };
 
-  // The isSuccess test is really not needed because we don't render unless it's true. However,
-  // it just seems clearer to keep the test here as we are using queryStates[].data
   const _displayViewType = (id) => {
     switch (viewType) {
       case constants.GRAPH:
@@ -175,7 +217,6 @@ function RoomsMonitor({
     return Object.values(values);
   };
 
-  // @TODO VMT should have a standard way of displaying timestamps, perhaps in utilities. This function should be there.
   const _roomDateStamp = (lastUpdated) => {
     return dateAndTime.toDateTimeString(lastUpdated);
   };
@@ -213,60 +254,69 @@ function RoomsMonitor({
           </Fragment>
         </div>
         {_adminWarning()}
-        {Object.keys(populatedRooms).length === 0 && (
+        {Object.keys(populatedRooms).length === 0 ? (
           <div className={classes.NoSnapshot}>No rooms to display</div>
-        )}
-        <div className={classes.TileGroup}>
-          {Object.values(populatedRooms).map((room) => {
-            // for each of the rooms managed by a user display its title bar (title and menu) and
-            // then the particular view type.
-            return (
-              <div key={room._id} className={classes.Tile}>
-                <div className={classes.TileContainer}>
-                  <div
-                    className={classes.Title}
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      justifyContent: 'flex-start',
-                      alignItems: 'center',
-                      marginBottom: '5px',
-                    }}
-                  >
-                    <DropdownMenu
-                      list={_makeMenu(room._id)}
-                      name={<i className="fas fa-bars" />}
-                    />
-                    {populatedRooms[room._id] ? (
-                      <Fragment>
-                        {populatedRooms[room._id].name}
-                        <span className={classes.Timestamp}>
-                          updated:{' '}
-                          {_roomDateStamp(populatedRooms[room._id].updatedAt)}{' '}
-                        </span>
-                        <i
-                          className="fas fa-external-link-alt"
-                          title="Open a quick view of the room"
-                          onClick={() => {
-                            _openModal(room._id);
-                          }}
-                          onKeyDown={() => {
-                            _openModal(room._id);
-                          }}
-                          tabIndex="-1"
-                          role="button"
-                        />
-                      </Fragment>
-                    ) : (
-                      'Loading...'
+        ) : (
+          <div className={classes.TileGroup}>
+            {Object.values(populatedRooms).map((room, index) => {
+              // for each of the rooms managed by a user display its title bar (title and menu) and
+              // then the particular view type.
+              return (
+                <div
+                  key={room._id}
+                  className={classes.Tile}
+                  ref={divRefs[index]}
+                  id={room._id}
+                >
+                  <div className={classes.TileContainer}>
+                    <div
+                      className={classes.Title}
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        justifyContent: 'flex-start',
+                        alignItems: 'center',
+                        marginBottom: '5px',
+                      }}
+                    >
+                      <DropdownMenu
+                        list={_makeMenu(room._id)}
+                        name={<i className="fas fa-bars" />}
+                      />
+                      {populatedRooms[room._id] ? (
+                        <Fragment>
+                          {populatedRooms[room._id].name}
+                          <span className={classes.Timestamp}>
+                            updated:{' '}
+                            {_roomDateStamp(populatedRooms[room._id].updatedAt)}{' '}
+                          </span>
+                          <i
+                            className="fas fa-external-link-alt"
+                            title="Open a quick view of the room"
+                            onClick={() => {
+                              _openModal(room._id);
+                            }}
+                            onKeyDown={() => {
+                              _openModal(room._id);
+                            }}
+                            tabIndex="-1"
+                            role="button"
+                          />
+                        </Fragment>
+                      ) : (
+                        'Loading...'
+                      )}
+                    </div>
+                    {isLoading.includes(room._id) && (
+                      <div className={classes.Spinner} />
                     )}
+                    {_displayViewType(room._id)}
                   </div>
-                  {_displayViewType(room._id)}
                 </div>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        )}
       </div>
       <BigModal show={showModal} closeModal={() => setShowModal(false)}>
         <RoomViewer
@@ -342,12 +392,16 @@ RoomsMonitor.propTypes = {
   }).isRequired,
   onThumbnailSelected: PropTypes.func,
   context: PropTypes.string.isRequired,
+  onVisible: PropTypes.func,
+  isLoading: PropTypes.arrayOf(PropTypes.string),
 };
 
 RoomsMonitor.defaultProps = {
   tabIndex: undefined,
   screenIndex: undefined,
   onThumbnailSelected: () => {},
+  onVisible: () => {},
+  isLoading: [],
 };
 
 ChartUpdater.propTypes = {
@@ -372,4 +426,6 @@ DropdownMenu.defaultProps = {
 
 const mapStateToProps = (state) => ({ user: state.user });
 
-export default connect(mapStateToProps)(RoomsMonitor);
+export default connect(mapStateToProps)(
+  React.memo(RoomsMonitor, (prev, next) => isEqual(prev, next))
+);

--- a/client/src/Containers/Monitoring/RoomsMonitor.js
+++ b/client/src/Containers/Monitoring/RoomsMonitor.js
@@ -92,6 +92,7 @@ function RoomsMonitor({
   // THE DIVS THAT CHANGED VISIBILITY. We use the visibilityRef to keep track of tje visibility of all the divs that can
   // be displayed.
   React.useEffect(() => {
+    if (observerRef.current) observerRef.current.disconnect();
     // for some reason, vscode doesn't recognize InterserctionObserver
     // eslint-disable-next-line no-undef
     observerRef.current = new IntersectionObserver((entries) => {

--- a/client/src/Containers/Monitoring/monitoringView.css
+++ b/client/src/Containers/Monitoring/monitoringView.css
@@ -70,6 +70,7 @@
   width: 100%;
   border-radius: 3px;
   box-shadow: lightShadow;
+  position: relative;
 }
 
 .Title {
@@ -105,3 +106,26 @@
   flex: 1;
   margin: 0 15px;
 }
+
+.Spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border-top: 4px solid #3498db;
+  border-right: 4px solid transparent;
+  animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+


### PR DESCRIPTION
This PR changes Monitoring such that only rooms that are visible on the user's screen will update. This approach should reduce the server load that sometimes occurs when someone is on the monitoring tab.

This PR also fixes the bug whereby room selections weren't being saved when navigating away and back to the monitoring page.

Note that this PR implements the change only to Monitoring right now. If we find that this approach works, we will also implement it in CoursePreview and Template Preview.