### PR TITLE
Hide alias features

### DIFF
--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -52,9 +52,9 @@ class Room extends Component {
       guestMode: true,
       tabs: [
         { name: 'Details' },
-        ...(this.shouldShowMembers() ? [{ name: 'Members' }] : []),
-        { name: 'Preview' },
-        { name: 'Stats' },
+        ...(this.shouldShowTab() ? [{ name: 'Members' }] : []),
+        ...(this.shouldShowTab() ? [{ name: 'Preview' }] : []),
+        ...(this.shouldShowTab() ? [{ name: 'Stats' }] : []),
         { name: 'Settings' },
       ],
       firstView: false,
@@ -192,9 +192,9 @@ class Room extends Component {
     }
   }
 
-  // Don't display Members tab if:
+  // Don't display Members, Preview, or Stats tabs if:
   // aliased usernames are turned on and user is a facilitator
-  shouldShowMembers = () => {
+  shouldShowTab = () => {
     const { room } = this.props;
     // used because room is sometimes not fully loaded from community
     // & does not always loaded in without settings

--- a/client/src/Layout/BoxList/BoxList.js
+++ b/client/src/Layout/BoxList/BoxList.js
@@ -41,6 +41,20 @@ const boxList = (props) => {
     return `${days} day${days > 1 ? 's' : ''} ago`;
   };
 
+  // hide Preiew icon if room is aliased & user is a participant
+  const iconsToDiplay = (listItem) => {
+    if (resource === 'rooms') {
+      if (
+        listItem.settings &&
+        listItem.settings.displayAliasedUsernames &&
+        listItem.myRole === 'participant'
+      ) {
+        return icons.filter((icon) => icon.title.toLowerCase() !== 'preview');
+      }
+    }
+    return icons;
+  };
+
   let listElems = "There doesn't appear to be anything here yet";
   if (list.length > 0) {
     listElems = list.map((item) => {
@@ -101,7 +115,7 @@ const boxList = (props) => {
                 locked={item.privacySetting === 'private'} // @TODO Should it appear locked if the user has access ? I can see reasons for both
                 details={details}
                 listType={listType}
-                customIcons={icons}
+                customIcons={iconsToDiplay(item)}
                 resource={resource}
               >
                 {item.description}


### PR DESCRIPTION
Hide the following features for participants viewing aliased rooms:
- Preview & Stats tabs in the Room Lobby
- Preview icon in myVMT