### PR TITLE
Populate via pipeline

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -179,12 +179,46 @@ router.get('/findAllMatchingIds/:resource/populated', (req, res) => {
   const { ids = [], events = false } = req.query;
 
   try {
-    return controller
-      .getPopulatedById(ids, { events })
-      .select(
-        'creator user chat members currentMembers course activity tabs createdAt updatedAt name'
-      )
-      .then((results) => res.json({ results }));
+    return (
+      controller
+        .getPopulatedById(ids, { events })
+        // .select(
+        //   'creator user chat members currentMembers course activity tabs createdAt updatedAt name'
+        // )
+        .then((results) => {
+          const selectedResults = results.map((room) => {
+            const {
+              _id,
+              name,
+              creator,
+              user,
+              chat,
+              members,
+              currentMembers,
+              course,
+              activity,
+              tabs,
+              createdAt,
+              updatedAt,
+            } = room;
+            return {
+              _id,
+              name,
+              creator,
+              user,
+              chat,
+              members,
+              currentMembers,
+              course,
+              activity,
+              tabs,
+              createdAt,
+              updatedAt,
+            };
+          });
+          res.json({ results: selectedResults });
+        })
+    );
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(`Error get ${resource}: ${err}`);


### PR DESCRIPTION
Change the strategy for populating rooms from the DB to use Mongo directly rather than Mongoose. Theoretically, a Mongo pipeline should be more efficient than using Mongoose find plus multiple populate() calls.