### PR TITLE
Monitor update by visible

### DIFF
--- a/client/src/Containers/Monitoring/RoomPreview.js
+++ b/client/src/Containers/Monitoring/RoomPreview.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { usePopulatedRoom } from 'utils/utilityHooks';
-import { Loading } from 'Components';
 import RoomViewer from './RoomViewer';
+import classes from './monitoringView.css';
 
 /**
  * The RoomPreview provides a snapshot of a room, with the main math space (as a Thumbnail), Chat, and Attendance views.
@@ -13,7 +13,14 @@ function RoomPreview({ roomId }) {
     refetchInterval: 10000, // check for new info every 10 seconds
   });
 
-  return isSuccess ? <RoomViewer populatedRoom={data} /> : <Loading />;
+  const minimalRoom = { members: [], currentMembers: [], chat: [], tabs: [] };
+
+  return (
+    <div style={{ position: 'relative', minHeight: '50vh', minWidth: '80vw' }}>
+      <RoomViewer populatedRoom={isSuccess ? data : minimalRoom} />
+      {!isSuccess && <div className={classes.Spinner} />}
+    </div>
+  );
 }
 
 RoomPreview.propTypes = {

--- a/client/src/Containers/Monitoring/RoomsMonitor.js
+++ b/client/src/Containers/Monitoring/RoomsMonitor.js
@@ -11,7 +11,8 @@ import {
 import Chart from 'Containers/Stats/Chart';
 import statsReducer, { initialState } from 'Containers/Stats/statsReducer';
 import { dateAndTime, useUIState } from 'utils';
-import { debounce, isEqual } from 'lodash';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import Thumbnails from './Thumbnails';
 import QuickChat from './QuickChat';
 import classes from './monitoringView.css';

--- a/client/src/Containers/Monitoring/monitoringView.css
+++ b/client/src/Containers/Monitoring/monitoringView.css
@@ -70,6 +70,7 @@
   width: 100%;
   border-radius: 3px;
   box-shadow: lightShadow;
+  position: relative;
 }
 
 .Title {
@@ -105,3 +106,26 @@
   flex: 1;
   margin: 0 15px;
 }
+
+.Spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border-top: 4px solid #3498db;
+  border-right: 4px solid transparent;
+  animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -298,20 +298,22 @@ export function useSnapshots(callback, initialStore = {}) {
  * @param {object} [options={}] - See the docs for react-query's UseQuery for these options.
  */
 export function usePopulatedRoom(roomId, shouldBuildLog = false, options = {}) {
-  return useQuery(
+  return useMergedData(
     [roomId, { shouldBuildLog }], // index the query both by the room id and whether we have all the events & messages
-    () =>
-      API.getPopulatedById('rooms', roomId, false, shouldBuildLog).then(
-        (res) => {
-          const populatedRoom = res.data.result;
-          if (shouldBuildLog)
-            populatedRoom.log = buildLog(
-              populatedRoom.tabs,
-              populatedRoom.chat
-            );
-          return populatedRoom;
-        }
-      ),
+    (lastQueryTimes) =>
+      API.findAllMatchingIdsPopulated(
+        'rooms',
+        [roomId],
+        shouldBuildLog,
+        lastQueryTimes
+      ).then((res) => {
+        const populatedRoom = res.data.results[0];
+        if (shouldBuildLog)
+          populatedRoom.log = buildLog(populatedRoom.tabs, populatedRoom.chat);
+        return populatedRoom;
+      }),
+    () => [roomId],
+    (cache, fetchedData) => ({ ...cache, ...fetchedData }),
     options
   );
 }

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -3,12 +3,12 @@ import React, { useContext } from 'react';
 import html2canvas from 'html2canvas';
 import debounce from 'lodash/debounce';
 import keyBy from 'lodash/keyBy';
+import isEqual from 'lodash/isEqual';
 import { useQuery, useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { API, buildLog } from 'utils';
 import { ModalContext } from 'Components';
 import * as actionTypes from 'store/actions/actionTypes';
-import { isEqual } from 'lodash';
 
 const timeFrameFcns = {
   all: () => true,
@@ -209,6 +209,7 @@ export function useSnapshots(callback, initialStore = {}) {
     (key, snapshotObj) => {
       // console.log('starting snapshot for', key);
       if (!elementRef.current) {
+        // eslint-disable-next-line no-console
         console.log('no elementRef');
         return;
       }
@@ -236,9 +237,11 @@ export function useSnapshots(callback, initialStore = {}) {
             } else {
               callback({ ...snapshotObj, ...newSnap });
             }
+            // eslint-disable-next-line no-console
           } else console.log('snapshot not well formed:', dataURL);
         } else {
           cancelSnapshot.current = false;
+          // eslint-disable-next-line no-console
           console.log('snapshot cancelled');
         }
       });
@@ -314,16 +317,27 @@ export function usePopulatedRoom(roomId, shouldBuildLog = false, options = {}) {
 }
 
 /**
- * Hook that takes an array roomIds and returns those rooms in an object key'd by the ids. The object keys are in the same
+ * Hook that takes an array of roomIds and returns those rooms in an object key'd by the ids. The object keys are in the same
  * order as the original roomIds array.
+ *
+ * The hook uses the useMergedData hook so that it builds up a cache of responses and so we only pull from the DB rooms that have changed since the
+ * last request.
+ *
+ * If usePopulatedRoom receives an initialCache in the options, it'll make sure that all data merging includes that initial cache (fourth arg to useMergedData) and
+ * will key the query on the full set of ids (ie., all the ids from the initial cache). Note that this assumes that initialCache's keys are a superset of
+ * roomIds.
  */
 export function usePopulatedRooms(
   roomIds,
   shouldBuildLog = false,
   options = {}
 ) {
+  const initialCache = options.initialCache || {};
+  const queryKey = options.initialCache
+    ? Object.keys(options.initialCache)
+    : roomIds;
   return useMergedData(
-    [roomIds, { shouldBuildLog }], // index the query both by the room id and whether we have all the events & messages
+    [queryKey, { shouldBuildLog }], // index the query both by the room id and whether we have all the events & messages
     async (lastQueryTimes) => {
       // all of our API calls return the full xhttp object, with the data we want in the data>results field
       const {
@@ -349,7 +363,7 @@ export function usePopulatedRooms(
       return orderedRoomsById;
     },
     (results) => Object.keys(results),
-    (cache, fetchedData) => ({ ...cache, ...fetchedData }),
+    (cache, fetchedData) => ({ ...initialCache, ...cache, ...fetchedData }),
     options
   );
 }
@@ -427,7 +441,7 @@ export function useUIState(key, initialValue = {}) {
 /**
  * A custom hook that assumes the fetchFcn might sometimes not return all documents in a key bc they hadn't been updated since the last query.
  * The hook therefore uses a provided merge function to combine the new data coming in from the fetch with its own cache. The hook also keeps
- * track of the last query times organized by a provided extractIds function. @TODO: I NEED A WAY OF COMMUNICATING LASTQUERYTIMES TO FETCHFCN
+ * track of the last query times organized by a provided extractIds function.
  *
  * key - The key index of the query. Should be an array of objects, one field of which is the unique identifier extracted by extractIdsFcn
  * fetchFcn - A function to do the query
@@ -445,13 +459,14 @@ export function useMergedData(
   options = {}
 ) {
   const queryClient = useQueryClient();
-  const queryInfo = queryClient.getQueryData([key, 'useMergedData']) || {};
-  const lastQueryTimes = queryInfo.lastQueryTimes || {};
+  const lastQueryTimes =
+    queryClient.getQueryData([key, 'lastQueryTimes']) || {};
+  const cachedData = queryClient.getQueryData(key) || {};
 
   return useQuery(key, () => fetchFcn(lastQueryTimes), {
     onSuccess: (newData) => {
-      if (isEqual(queryInfo.data, newData)) return;
-      const mergedData = mergeFcn(queryInfo.data, newData);
+      if (isEqual(cachedData, newData)) return; // the onSuccess hook gets triggered when setQueryData gets called (see below)
+      const mergedData = mergeFcn(cachedData, newData);
       const newDataIds = extractIdsFcn(newData);
 
       const updatedLastQueryTimes = newDataIds.reduce(
@@ -461,16 +476,11 @@ export function useMergedData(
         }),
         {}
       );
-      const updatedQueryInfo = {
-        data: mergedData,
-        lastQueryTimes: {
-          ...queryInfo.lastQueryTimes,
-          ...updatedLastQueryTimes,
-        },
-      };
 
-      // we change the key because if we use the same key as the query, the onSuccess hook is triggered by setQueryData
-      queryClient.setQueryData([key, 'useMergedData'], updatedQueryInfo);
+      queryClient.setQueryData([key, 'lastQueryTimes'], {
+        ...lastQueryTimes,
+        ...updatedLastQueryTimes,
+      });
       queryClient.setQueryData(key, mergedData);
     },
     ...options,

--- a/server/controllers/RoomController.js
+++ b/server/controllers/RoomController.js
@@ -68,13 +68,17 @@ module.exports = {
     let queryFcn;
     if (Array.isArray(id)) {
       const queryTimes = params.lastQueryTimes || {};
-      queryFcn = () =>
-        db.Room.find({
-          $or: id.map((oneId) => ({
-            _id: oneId,
-            updatedAt: { $gt: new Date(queryTimes[oneId] || 0) },
-          })),
-        });
+      // handle no ids case separately because $or doesn't accept an empty array
+      queryFcn =
+        id.length === 0
+          ? db.Room.find({ _id: { $in: [] } })
+          : () =>
+              db.Room.find({
+                $or: id.map((oneId) => ({
+                  _id: oneId,
+                  updatedAt: { $gt: new Date(queryTimes[oneId] || 0) },
+                })),
+              });
     } else {
       queryFcn = () => db.Room.findById(id);
     }


### PR DESCRIPTION
This PR implements a strategy to reduce the load on the server during monitor/preview. Here, only those rooms that are visible on the screen are updated during monitoring/preview. If the user scrolls so that a new set of rooms are visible,  the system begins requesting only those rooms from the db. 