### PR TITLE
Centralize Google Icons into utils/icons

### DIFF
--- a/client/src/Containers/Archive.js
+++ b/client/src/Containers/Archive.js
@@ -7,7 +7,7 @@ import { API, useAppModal } from 'utils';
 import { Button, ToolTip } from 'Components';
 import { RoomPreview } from 'Containers';
 import { restoreArchivedRoom } from 'store/actions';
-import { STATUS } from 'constants.js';
+import { GOOGLE_ICONS } from 'constants.js';
 import classes from './Archive.css';
 
 const SKIP_VALUE = 20;
@@ -211,13 +211,18 @@ const Archive = () => {
       e.preventDefault();
       handleRestore(id);
     },
-    icon: (
-      <ToolTip text="Unarchive" delay={600}>
-        <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-          output
-        </span>
-      </ToolTip>
-    ),
+    generateIcon: (selectedIds) => {
+      const enableUnarchiveButton = selectedIds.length > 0;
+      const fontWeight = enableUnarchiveButton ? 'normal' : '200';
+      const cursor = enableUnarchiveButton ? 'pointer' : 'default';
+      const style = { fontWeight, cursor };
+
+      return (
+        <ToolTip text="Unarchive" delay={600}>
+          {GOOGLE_ICONS('unarchive', [classes.CustomIcon], style)}
+        </ToolTip>
+      );
+    },
   };
 
   const handleRestore = (id) => {
@@ -292,9 +297,7 @@ const Archive = () => {
       // icon: <i className="fas fa-external-link-alt" />,
       icon: (
         <ToolTip text="Preview" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            open_in_new
-          </span>
+          {GOOGLE_ICONS('preview', [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -306,9 +309,7 @@ const Archive = () => {
       },
       icon: (
         <ToolTip text="Replayer" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            replay
-          </span>
+          {GOOGLE_ICONS('replayer', [classes.CustomIcon])}
         </ToolTip>
       ),
     },

--- a/client/src/Containers/Archive.js
+++ b/client/src/Containers/Archive.js
@@ -3,11 +3,10 @@ import { useParams, useHistory, useRouteMatch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import debounce from 'lodash/debounce';
 import { ArchiveLayout } from 'Layout';
-import { API, useAppModal } from 'utils';
+import { API, useAppModal, GOOGLE_ICONS, getGoogleIcons } from 'utils';
 import { Button, ToolTip } from 'Components';
 import { RoomPreview } from 'Containers';
 import { restoreArchivedRoom } from 'store/actions';
-import { GOOGLE_ICONS } from 'constants.js';
 import classes from './Archive.css';
 
 const SKIP_VALUE = 20;
@@ -219,7 +218,7 @@ const Archive = () => {
 
       return (
         <ToolTip text="Unarchive" delay={600}>
-          {GOOGLE_ICONS('unarchive', [classes.CustomIcon], style)}
+          {getGoogleIcons(GOOGLE_ICONS.UNARCHIVE, [classes.CustomIcon], style)}
         </ToolTip>
       );
     },
@@ -297,7 +296,7 @@ const Archive = () => {
       // icon: <i className="fas fa-external-link-alt" />,
       icon: (
         <ToolTip text="Preview" delay={600}>
-          {GOOGLE_ICONS('preview', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.PREVIEW, [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -309,7 +308,7 @@ const Archive = () => {
       },
       icon: (
         <ToolTip text="Replayer" delay={600}>
-          {GOOGLE_ICONS('replayer', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.REPLAYER, [classes.CustomIcon])}
         </ToolTip>
       ),
     },

--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -34,7 +34,7 @@ import {
   updateUser,
 } from 'store/actions';
 import { getUserNotifications, getResourceTabTypes } from 'utils';
-import { STATUS } from 'constants.js';
+import { GOOGLE_ICONS, STATUS } from 'constants.js';
 import Members from './Members/Members';
 import Stats from './Stats/Stats';
 // import withPopulatedRoom from './Data/withPopulatedRoom';
@@ -596,38 +596,38 @@ class Room extends Component {
                       }}
                     >
                       <ToolTip text="Replayer" delay={600}>
-                        <span
-                          // theme={loading.loading ? 'SmallCancel' : 'Small'}
-                          // m={10}
-                          data-testid="Replayer"
-                          onClick={!loading.loading ? this.goToReplayer : null}
-                          onKeyDown={
-                            !loading.loading ? this.goToReplayer : null
+                        {GOOGLE_ICONS(
+                          'replayer',
+                          [classes.CustomIcon],
+                          {
+                            paddingRight: '0.5rem',
+                          },
+                          {
+                            'data-testid': 'Replayer',
+                            role: 'button',
+                            tabIndex: -1,
+                            onClick: !loading.loading
+                              ? this.goToReplayer
+                              : null,
+                            onKeyDown: !loading.loading
+                              ? this.goToReplayer
+                              : null,
                           }
-                          role="button"
-                          tabIndex={-1}
-                          className={`material-symbols-outlined ${classes.CustomIcon}`}
-                          style={{ paddingRight: '0.5rem' }}
-                        >
-                          replay
-                        </span>
+                        )}
                       </ToolTip>
                       {room.myRole === 'facilitator' && (
                         <ToolTip text="Archive This Room" delay={600}>
-                          <span
-                            data-testid="archive-room"
-                            onClick={
-                              !loading.loading ? this.showArchiveModal : null
-                            }
-                            onKeyDown={
-                              !loading.loading ? this.showArchiveModal : null
-                            }
-                            className={`material-symbols-outlined ${classes.CustomIcon}`}
-                            role="button"
-                            tabIndex={-1}
-                          >
-                            input
-                          </span>
+                          {GOOGLE_ICONS('archive', [classes.CustomIcon], null, {
+                            'data-testid': 'archive-room',
+                            role: 'button',
+                            tabIndex: -1,
+                            onClick: !loading.loading
+                              ? this.showArchiveModal
+                              : null,
+                            onKeyDown: !loading.loading
+                              ? this.showArchiveModal
+                              : null,
+                          })}
                         </ToolTip>
                       )}
                     </div>

--- a/client/src/Containers/RoomLobby.js
+++ b/client/src/Containers/RoomLobby.js
@@ -34,7 +34,8 @@ import {
   updateUser,
 } from 'store/actions';
 import { getUserNotifications, getResourceTabTypes } from 'utils';
-import { GOOGLE_ICONS, STATUS } from 'constants.js';
+import { STATUS } from 'constants.js';
+import { GOOGLE_ICONS, getGoogleIcons } from 'utils';
 import Members from './Members/Members';
 import Stats from './Stats/Stats';
 // import withPopulatedRoom from './Data/withPopulatedRoom';
@@ -596,8 +597,8 @@ class Room extends Component {
                       }}
                     >
                       <ToolTip text="Replayer" delay={600}>
-                        {GOOGLE_ICONS(
-                          'replayer',
+                        {getGoogleIcons(
+                          GOOGLE_ICONS.REPLAYER,
                           [classes.CustomIcon],
                           {
                             paddingRight: '0.5rem',
@@ -617,17 +618,22 @@ class Room extends Component {
                       </ToolTip>
                       {room.myRole === 'facilitator' && (
                         <ToolTip text="Archive This Room" delay={600}>
-                          {GOOGLE_ICONS('archive', [classes.CustomIcon], null, {
-                            'data-testid': 'archive-room',
-                            role: 'button',
-                            tabIndex: -1,
-                            onClick: !loading.loading
-                              ? this.showArchiveModal
-                              : null,
-                            onKeyDown: !loading.loading
-                              ? this.showArchiveModal
-                              : null,
-                          })}
+                          {getGoogleIcons(
+                            GOOGLE_ICONS.ARCHIVE,
+                            [classes.CustomIcon],
+                            null,
+                            {
+                              'data-testid': 'archive-room',
+                              role: 'button',
+                              tabIndex: -1,
+                              onClick: !loading.loading
+                                ? this.showArchiveModal
+                                : null,
+                              onKeyDown: !loading.loading
+                                ? this.showArchiveModal
+                                : null,
+                            }
+                          )}
                         </ToolTip>
                       )}
                     </div>

--- a/client/src/Layout/Archive/Archive.js
+++ b/client/src/Layout/Archive/Archive.js
@@ -37,6 +37,32 @@ const Archive = (props) => {
 
   const toggleRoomFilter = (type) => toggleFilter(`room-${type}`);
 
+  const SelectableBoxListCustomStyles = {
+    container: {},
+    header: {
+      maxWidth: '575px',
+      height: '35px',
+    },
+    checkbox: {
+      padding: '10px',
+      marginRight: '2rem',
+      background: 'rgb(239, 243, 246)',
+      border: '1px solid #ddd',
+      fontWeight: '600',
+      fontSize: '1.1em',
+      borderRadius: '3px',
+    },
+    selectactions: {
+      background: 'rgb(239, 243, 246)',
+      border: '1px solid #ddd',
+    },
+    contentbox: '',
+    Archive: {
+      fontWeight: 'light',
+    },
+    Unrchive: '',
+  };
+
   return (
     <React.Fragment>
       {actionComponent}
@@ -222,6 +248,7 @@ const Archive = (props) => {
             selectable
             icons={icons}
             selectActions={selectActions}
+            customStyle={SelectableBoxListCustomStyles}
           />
         )}
         {/* </div> */}

--- a/client/src/Layout/CourseRooms/CourseRooms.js
+++ b/client/src/Layout/CourseRooms/CourseRooms.js
@@ -17,8 +17,9 @@ import {
 } from 'utils';
 import { addUserRoleToResource } from 'store/utils';
 import { updateRoom, archiveRooms, restoreArchivedRoom } from 'store/actions';
-import { GOOGLE_ICONS, STATUS } from 'constants.js';
+import { STATUS } from 'constants.js';
 import NewResource from 'Containers/Create/NewResource/NewResource';
+import { getGoogleIcons, GOOGLE_ICONS } from 'utils';
 
 import classes from './courseRooms.css';
 
@@ -132,7 +133,7 @@ const CourseRooms = (props) => {
       },
       icon: (
         <ToolTip text="Preview" delay={600}>
-          {GOOGLE_ICONS('preview', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.PREVIEW, [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -144,7 +145,7 @@ const CourseRooms = (props) => {
       },
       icon: (
         <ToolTip text="Replayer" delay={600}>
-          {GOOGLE_ICONS('replayer', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.REPLAYER, [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -166,7 +167,9 @@ const CourseRooms = (props) => {
         }`;
         return (
           <ToolTip text={toDisplay} delay={600}>
-            {GOOGLE_ICONS(toDisplay, [classes.CustomIcon])}
+            {getGoogleIcons(GOOGLE_ICONS[toDisplay.toUpperCase()], [
+              classes.CustomIcon,
+            ])}
           </ToolTip>
         );
       },
@@ -193,8 +196,8 @@ const CourseRooms = (props) => {
 
       return (
         <ToolTip text="Archive" delay={600}>
-          {GOOGLE_ICONS(
-            'archive',
+          {getGoogleIcons(
+            GOOGLE_ICONS.ARCHIVE,
             [classes.CustomIcon, classes.SelectActionsIcon],
             style
           )}
@@ -222,8 +225,8 @@ const CourseRooms = (props) => {
       const style = { fontWeight, cursor };
       return (
         <ToolTip text="Unarchive" delay={600}>
-          {GOOGLE_ICONS(
-            'unarchive',
+          {getGoogleIcons(
+            GOOGLE_ICONS.UNARCHIVE,
             [classes.CustomIcon, classes.SelectActionsIcon],
             style
           )}

--- a/client/src/Layout/CourseRooms/CourseRooms.js
+++ b/client/src/Layout/CourseRooms/CourseRooms.js
@@ -17,7 +17,7 @@ import {
 } from 'utils';
 import { addUserRoleToResource } from 'store/utils';
 import { updateRoom, archiveRooms, restoreArchivedRoom } from 'store/actions';
-import { STATUS } from 'constants.js';
+import { GOOGLE_ICONS, STATUS } from 'constants.js';
 import NewResource from 'Containers/Create/NewResource/NewResource';
 
 import classes from './courseRooms.css';
@@ -130,13 +130,9 @@ const CourseRooms = (props) => {
         e.preventDefault();
         goToRoomPreview(id);
       },
-      // icon: <i className="fas fa-external-link-alt" />,
       icon: (
         <ToolTip text="Preview" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            preview
-            {/* gallery_thumbnail */}
-          </span>
+          {GOOGLE_ICONS('preview', [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -148,9 +144,7 @@ const CourseRooms = (props) => {
       },
       icon: (
         <ToolTip text="Replayer" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            autoplay
-          </span>
+          {GOOGLE_ICONS('replayer', [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -167,28 +161,12 @@ const CourseRooms = (props) => {
       },
       generateIcon: (id) => {
         const currRoom = rooms[id];
-
-        const toDisplay = {
-          text: `${currRoom.status === 'default' ? 'Archive' : 'Unarchive'}`,
-          icon:
-            currRoom.status === 'default' ? (
-              <span
-                className={`material-symbols-outlined ${classes.CustomIcon}`}
-              >
-                archive
-              </span>
-            ) : (
-              <span
-                className={`material-symbols-outlined ${classes.CustomIcon}`}
-              >
-                unarchive
-              </span>
-            ),
-        };
-
+        const toDisplay = `${
+          currRoom.status === 'default' ? 'Archive' : 'Unarchive'
+        }`;
         return (
-          <ToolTip text={toDisplay.text} delay={600}>
-            <span>{toDisplay.icon}</span>
+          <ToolTip text={toDisplay} delay={600}>
+            {GOOGLE_ICONS(toDisplay, [classes.CustomIcon])}
           </ToolTip>
         );
       },
@@ -215,13 +193,11 @@ const CourseRooms = (props) => {
 
       return (
         <ToolTip text="Archive" delay={600}>
-          <span
-            className={`material-symbols-outlined ${classes.CustomIcon} ${classes.SelectActionsIcon}`}
-            data-testid="Archive"
-            style={style}
-          >
-            archive
-          </span>
+          {GOOGLE_ICONS(
+            'archive',
+            [classes.CustomIcon, classes.SelectActionsIcon],
+            style
+          )}
         </ToolTip>
       );
     },
@@ -246,13 +222,11 @@ const CourseRooms = (props) => {
       const style = { fontWeight, cursor };
       return (
         <ToolTip text="Unarchive" delay={600}>
-          <span
-            className={`material-symbols-outlined ${classes.CustomIcon} ${classes.SelectActionsIcon}`}
-            data-testid="Archive"
-            style={style}
-          >
-            unarchive
-          </span>
+          {GOOGLE_ICONS(
+            'unarchive',
+            [classes.CustomIcon, classes.SelectActionsIcon],
+            style
+          )}
         </ToolTip>
       );
     },

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -12,7 +12,8 @@ import SelectableBoxList from 'Layout/SelectableBoxList/SelectableBoxList';
 import { Button, BigModal, Modal, SortUI, ToolTip } from 'Components';
 import { RoomPreview } from 'Containers';
 import { updateRoom, archiveRooms } from 'store/actions';
-import { GOOGLE_ICONS, STATUS } from 'constants.js';
+import { STATUS } from 'constants.js';
+import { GOOGLE_ICONS, getGoogleIcons } from 'utils';
 import BoxList from '../../BoxList/BoxList';
 import NewResource from '../../../Containers/Create/NewResource/NewResource';
 import classes from './resourceList.css';
@@ -161,8 +162,8 @@ const ResourceList = ({
     },
     icon: (
       <ToolTip text="Archive" delay={600}>
-        {GOOGLE_ICONS(
-          'archive',
+        {getGoogleIcons(
+          GOOGLE_ICONS.ARCHIVE,
           [classes.CustomIcon],
           { fontSize: '23px' },
           { 'data-testid': 'Archive' }
@@ -182,7 +183,7 @@ const ResourceList = ({
       // icon: <i className="fas fa-external-link-alt" />,
       icon: (
         <ToolTip text="Preview" delay={600}>
-          {GOOGLE_ICONS('preview', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.PREVIEW, [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -194,7 +195,7 @@ const ResourceList = ({
       },
       icon: (
         <ToolTip text="Replayer" delay={600}>
-          {GOOGLE_ICONS('replayer', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.REPLAYER, [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -207,7 +208,7 @@ const ResourceList = ({
       },
       icon: (
         <ToolTip text="Archive" delay={600}>
-          {GOOGLE_ICONS('archive', [classes.CustomIcon])}
+          {getGoogleIcons(GOOGLE_ICONS.ARCHIVE, [classes.CustomIcon])}
         </ToolTip>
       ),
     },

--- a/client/src/Layout/Dashboard/MainContent/ResourceList.js
+++ b/client/src/Layout/Dashboard/MainContent/ResourceList.js
@@ -12,7 +12,7 @@ import SelectableBoxList from 'Layout/SelectableBoxList/SelectableBoxList';
 import { Button, BigModal, Modal, SortUI, ToolTip } from 'Components';
 import { RoomPreview } from 'Containers';
 import { updateRoom, archiveRooms } from 'store/actions';
-import { STATUS } from 'constants.js';
+import { GOOGLE_ICONS, STATUS } from 'constants.js';
 import BoxList from '../../BoxList/BoxList';
 import NewResource from '../../../Containers/Create/NewResource/NewResource';
 import classes from './resourceList.css';
@@ -161,13 +161,12 @@ const ResourceList = ({
     },
     icon: (
       <ToolTip text="Archive" delay={600}>
-        <span
-          className={`material-symbols-outlined ${classes.CustomIcon}`}
-          data-testid="Archive"
-          style={{ fontSize: '23px' }}
-        >
-          input
-        </span>
+        {GOOGLE_ICONS(
+          'archive',
+          [classes.CustomIcon],
+          { fontSize: '23px' },
+          { 'data-testid': 'Archive' }
+        )}
       </ToolTip>
     ),
   };
@@ -183,9 +182,7 @@ const ResourceList = ({
       // icon: <i className="fas fa-external-link-alt" />,
       icon: (
         <ToolTip text="Preview" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            open_in_new
-          </span>
+          {GOOGLE_ICONS('preview', [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -197,9 +194,7 @@ const ResourceList = ({
       },
       icon: (
         <ToolTip text="Replayer" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            replay
-          </span>
+          {GOOGLE_ICONS('replayer', [classes.CustomIcon])}
         </ToolTip>
       ),
     },
@@ -212,9 +207,7 @@ const ResourceList = ({
       },
       icon: (
         <ToolTip text="Archive" delay={600}>
-          <span className={`material-symbols-outlined ${classes.CustomIcon}`}>
-            input
-          </span>
+          {GOOGLE_ICONS('archive', [classes.CustomIcon])}
         </ToolTip>
       ),
     },

--- a/client/src/Layout/SelectableBoxList/SelectableBoxList.css
+++ b/client/src/Layout/SelectableBoxList/SelectableBoxList.css
@@ -38,5 +38,5 @@
 
 .SelectActions {
   display: flex;
-
+  align-items: center;
 }

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // STATUS and ROLE must be kept consistent with server/constants/status.js and server/constants/role.js
 export const STATUS = {
   ARCHIVED: 'archived',
@@ -15,51 +13,3 @@ export const ROLE = {
 };
 
 export const GRAPH_HEIGHT = window.innerHeight - 400;
-
-export const GOOGLE_ICONS = (
-  iconType,
-  customClassNames = null,
-  customStyle = null,
-  others // onClick, data-testid, etc. ...
-) => {
-  let googleIconName = '';
-  // eslint-disable-next-line react/destructuring-assignment, default-case
-  switch (iconType.toUpperCase()) {
-    /* PREVIOUSLY USED GOOGLE_ICONS */
-    // case 'PREVIEW':
-    //   googleIconName = 'open_in_new';
-    //   break;
-    // case 'REPLAYER':
-    //   googleIconName = 'replay';
-    //   break;
-    // case 'ARCHIVE':
-    //   googleIconName = 'archive';
-    //   break;
-    // case 'UNARCHIVE':
-    //   googleIconName = 'output';
-    //   break;
-    case 'PREVIEW':
-      googleIconName = 'preview';
-      break;
-    case 'REPLAYER':
-      googleIconName = 'autoplay';
-      break;
-    case 'ARCHIVE':
-      googleIconName = 'archive';
-      break;
-    case 'UNARCHIVE':
-      googleIconName = 'unarchive';
-      break;
-  }
-
-  return (
-    <span
-      className={`material-symbols-outlined ${Array.isArray(customClassNames) &&
-        customClassNames.join(', ')}`}
-      style={customStyle}
-      {...others}
-    >
-      {googleIconName}
-    </span>
-  );
-};

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,7 +1,6 @@
-// This file must be kept consistent with server/constants/status.js and server/constants/role.js
+import React from 'react';
 
-export const GRAPH_HEIGHT = window.innerHeight - 400;
-
+// STATUS and ROLE must be kept consistent with server/constants/status.js and server/constants/role.js
 export const STATUS = {
   ARCHIVED: 'archived',
   TRASHED: 'trashed',
@@ -13,4 +12,54 @@ export const ROLE = {
   FACILITATOR: 'facilitator',
   PARTICIPANT: 'participant',
   GUEST: 'guest',
+};
+
+export const GRAPH_HEIGHT = window.innerHeight - 400;
+
+export const GOOGLE_ICONS = (
+  iconType,
+  customClassNames = null,
+  customStyle = null,
+  others // onClick, data-testid, etc. ...
+) => {
+  let googleIconName = '';
+  // eslint-disable-next-line react/destructuring-assignment, default-case
+  switch (iconType.toUpperCase()) {
+    /* PREVIOUSLY USED GOOGLE_ICONS */
+    // case 'PREVIEW':
+    //   googleIconName = 'open_in_new';
+    //   break;
+    // case 'REPLAYER':
+    //   googleIconName = 'replay';
+    //   break;
+    // case 'ARCHIVE':
+    //   googleIconName = 'archive';
+    //   break;
+    // case 'UNARCHIVE':
+    //   googleIconName = 'output';
+    //   break;
+    case 'PREVIEW':
+      googleIconName = 'preview';
+      break;
+    case 'REPLAYER':
+      googleIconName = 'autoplay';
+      break;
+    case 'ARCHIVE':
+      googleIconName = 'archive';
+      break;
+    case 'UNARCHIVE':
+      googleIconName = 'unarchive';
+      break;
+  }
+
+  return (
+    <span
+      className={`material-symbols-outlined ${Array.isArray(customClassNames) &&
+        customClassNames.join(', ')}`}
+      style={customStyle}
+      {...others}
+    >
+      {googleIconName}
+    </span>
+  );
 };

--- a/client/src/utils/icons.js
+++ b/client/src/utils/icons.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export const GOOGLE_ICONS = {
+  PREVIEW: 'preview',
+  REPLAYER: 'autoplay',
+  ARCHIVE: 'archive',
+  UNARCHIVE: 'unarchive',
+};
+
+export const getGoogleIcons = (
+  iconType,
+  customClassNames = null,
+  customStyle = null,
+  others // onClick, data-testid, etc. ...
+) => {
+  return (
+    <span
+      className={`material-symbols-outlined ${Array.isArray(customClassNames) &&
+        customClassNames.join(', ')}`}
+      style={customStyle}
+      {...others}
+    >
+      {iconType}
+    </span>
+  );
+};

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -19,3 +19,4 @@ export { default as amIAFacilitator } from './amIAFacilitator';
 export { default as addColors } from './addColors';
 export { default as hexToRGBA } from './hexToRGBA';
 export { default as dateAndTime } from './dateAndTime';
+export { GOOGLE_ICONS, getGoogleIcons } from './icons';


### PR DESCRIPTION
Previously, Google icons were created in each file they were used in. 
Now, if we need to change a Google icon only one file needs updated. 