### PR TITLE
Tab update bug fix on release control

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -119,7 +119,8 @@ class Workspace extends Component {
         cancelSnapshots,
         getSnapshot,
       } = useSnapshots((newSnapshot) => {
-        const { currentTabId } = this.state;
+        const { controlState } = this.props;
+        const { currentTabId } = controlState;
         const updateBody = { snapshot: newSnapshot };
         API.put('tabs', currentTabId, updateBody).then(() => {
           this.updateTab(currentTabId, updateBody);

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -305,8 +305,10 @@ export function usePopulatedRoom(roomId, shouldBuildLog = false, options = {}) {
         shouldBuildLog,
         lastQueryTimes
       ).then((res) => {
-        const populatedRoom = res.data.results[0];
-        if (shouldBuildLog)
+        const populatedRoom = res.data.results[0] || {};
+        // temp fix to handle Room/CourseLobby reload crashing the app when in
+        // Stats > Graph view
+        if (shouldBuildLog && populatedRoom.tabs && populatedRoom.chat)
           populatedRoom.log = buildLog(populatedRoom.tabs, populatedRoom.chat);
         return populatedRoom;
       }),


### PR DESCRIPTION
In Workspace componentDidMount, API.put('tabs', currentTabId, ...) was failing because we hadn't yet retrieved the currentTabId from the controlState and instead used the old method of retrieving from state, which no longer tracks currentTabId. 

All of this is triggered by a release control update event.