### PR TITLE
Fix Error: Cannot set headers after they are sent to the client

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -254,7 +254,7 @@ router.get(
           isTrashed: false,
           [field]: id,
         })
-        .then((result) => res.json({ result }).sendStatus(200));
+        .then((result) => res.status(200).json({ result }));
     } catch (err) {
       console.error(`Error getting ${resource} rooms/${id}: ${err}`);
 


### PR DESCRIPTION
This error occurred in a facilitator's course lobby. 