### PR TITLE
Corrects bugs in how control is indicated in the Current Members list

### DIFF
--- a/client/src/Containers/Replayer/SharedReplayer.js
+++ b/client/src/Containers/Replayer/SharedReplayer.js
@@ -573,6 +573,7 @@ class SharedReplayer extends Component {
                 currentMembers={currentMembers}
                 expanded
                 activeMember={activeMember}
+                inControl={activeMember}
               />
             ) : null
           }

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -618,7 +618,7 @@ class Workspace extends Component {
               ? [
                   ...Object.values(controlState.controllers),
                   ...[controlState.controlledBy],
-                ]
+                ].filter((x) => !!x) // filter out undefined
               : controlState.controlledBy
           }
           expanded={membersExpanded}

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -615,8 +615,11 @@ class Workspace extends Component {
           }
           activeMember={
             controlState.controllers
-              ? Object.values(controlState.controllers)
-              : ''
+              ? [
+                  ...Object.values(controlState.controllers),
+                  ...[controlState.controlledBy],
+                ]
+              : controlState.controlledBy
           }
           expanded={membersExpanded}
           toggleExpansion={this.toggleExpansion}
@@ -1284,6 +1287,7 @@ Workspace.propTypes = {
     controlledBy: PropTypes.string,
     currentTabId: PropTypes.string,
     matches: PropTypes.func,
+    controllers: PropTypes.arrayOf(PropTypes.string),
   }),
   sendControlEvent: PropTypes.func,
 };
@@ -1300,6 +1304,7 @@ Workspace.defaultProps = {
     inControl: null,
     controlledBy: null,
     currentTabId: null,
+    controllers: [],
   },
   sendControlEvent: () => {},
 };

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -613,14 +613,8 @@ class Workspace extends Component {
               ? tempCurrentMembers
               : populatedRoom.getCurrentMembers(currentMembers)
           }
-          activeMember={
-            controlState.controllers
-              ? [
-                  ...Object.values(controlState.controllers),
-                  ...[controlState.controlledBy],
-                ].filter((x) => !!x) // filter out undefined
-              : controlState.controlledBy
-          }
+          activeMember={controlState.controlledBy}
+          inControl={controlState.controlledBy}
           expanded={membersExpanded}
           toggleExpansion={this.toggleExpansion}
           tabs={tabs}
@@ -634,9 +628,13 @@ class Workspace extends Component {
         expanded={membersExpanded}
         activeMember={
           controlState.controllers
-            ? Object.values(controlState.controllers)
-            : ''
+            ? [
+                ...Object.values(controlState.controllers),
+                ...[controlState.controlledBy],
+              ].filter((x) => !!x) // filter out undefined
+            : controlState.controlledBy
         }
+        inControl={controlState.controlledBy}
         currentMembers={
           temp
             ? tempCurrentMembers
@@ -992,9 +990,7 @@ class Workspace extends Component {
       connectUpdatedRoom,
       save,
       temp,
-      tempMembers,
       connectUpdateRoomTab,
-      tempCurrentMembers,
       connectUpdateUserSettings,
       resetRoom,
       user,
@@ -1002,7 +998,6 @@ class Workspace extends Component {
     } = this.props;
     const {
       tabs: currentTabs,
-      currentMembers: activeMembers,
       log,
       membersExpanded,
       toolsExpanded,
@@ -1032,26 +1027,6 @@ class Workspace extends Component {
     const { currentTabId } = controlState;
     const inControl = controlState.inControl || controlStates.NONE;
 
-    // const currentMembers = (
-    //   <DisplayTabsCM
-    //     members={temp ? tempMembers : populatedRoom.members}
-    //     // currentMembers={temp ? tempCurrentMembers : activeMembers}
-    //     currentMembers={
-    //       temp
-    //         ? tempCurrentMembers
-    //         : populatedRoom.getCurrentMembers(activeMembers)
-    //     }
-    //     activeMember={
-    //       controlState.controllers
-    //         ? Object.values(controlState.controllers)
-    //         : ''
-    //     }
-    //     expanded={membersExpanded}
-    //     toggleExpansion={this.toggleExpansion}
-    //     tabs={currentTabs}
-    //   />
-    // );
-    // determine if we should render DisplayTabsCM or CurrentMembers
     const currentMembers = this.configureCurrentMembersComponent();
     const tabs = (
       <Tabs

--- a/client/src/store/reducers/activitiesReducer.js
+++ b/client/src/store/reducers/activitiesReducer.js
@@ -44,6 +44,7 @@ const reducer = (state = initialState, action) => {
     // @TODO if we've created a new activity alert the user so we can redirect
     // to the activity --> do this by updating the sto
     case actionTypes.ADD_ACTIVITY_ROOMS: {
+      // We will catch an error if an activity had been trashed
       try {
         const updatedActivities = { ...state.byId };
         updatedActivities[action.activityId].rooms = updatedActivities[
@@ -54,12 +55,14 @@ const reducer = (state = initialState, action) => {
           byId: updatedActivities,
         };
       } catch (error) {
+        console.log('There was an error ADD_ACTIVITY_ROOMS', error);
         return {
           ...state,
         };
       }
     }
     case actionTypes.REMOVE_ACTIVITY_ROOM: {
+      // We will catch an error if an activity had been trashed
       try {
         const updatedById = { ...state.byId };
         const updatedActivityRooms = updatedById[
@@ -71,6 +74,7 @@ const reducer = (state = initialState, action) => {
           byId: updatedById,
         };
       } catch (error) {
+        console.log('There was an error REMOVE_ACTIVITY_ROOMS', error);
         return {
           ...state,
         };


### PR DESCRIPTION
This PR fixes some errors in how control was indicated in the Current Members list, especially when multiple people can be in control (independent tab control):
- anyone in control on any tab will now be highlighted in the Current Members list
- The name of the person currently in control on the current tab will show in the information area above the members' list

PR also includes some code cleaning and documentation.