### PR TITLE
Fix stack overflow error by using for loops instead of math.min & math.max

### DIFF
--- a/client/src/Containers/Stats/statsReducer.js
+++ b/client/src/Containers/Stats/statsReducer.js
@@ -2,6 +2,26 @@
 import { max } from 'd3';
 import { processData, processCourseData, dateFormatMap } from './stats.utils';
 
+const maxTimestamp = (array) => {
+  let maxValue = array[0].timestamp;
+  for (let i = 1; i < array.length; i++) {
+    if (array[i].timestamp > maxValue) {
+      maxValue = array[i].timestamp;
+    }
+  }
+  return maxValue;
+};
+
+const minTimestamp = (array) => {
+  let minValue = array[0].timestamp;
+  for (let i = 1; i < array.length; i++) {
+    if (array[i].timestamp < minValue) {
+      minValue = array[i].timestamp;
+    }
+  }
+  return minValue;
+};
+
 export const initialState = {
   byUser: false,
   byEvent: false,
@@ -32,8 +52,8 @@ export default (state = initialState, action) => {
     case 'GENERATE_DATA': {
       let { data } = action;
       const { users, events } = state;
-      const start = Math.min(...data.map((d) => d.timestamp));
-      const end = Math.max(...data.map((d) => d.timestamp));
+      const start = minTimestamp(data);
+      const end = maxTimestamp(data);
       const rawDuration = end - start;
       data = data.filter((d) => !d.isMultiPart);
 
@@ -200,8 +220,8 @@ export default (state = initialState, action) => {
       let { data } = action;
       if (data.length === 0) return state;
       const { users, events } = state;
-      const start = Math.min(...data.map((d) => d.timestamp));
-      const end = Math.max(...data.map((d) => d.timestamp));
+      const start = minTimestamp(data);
+      const end = maxTimestamp(data);
       const rawDuration = end - start;
       data = data.filter((d) => !d.isMultiPart);
 


### PR DESCRIPTION
This pr fixes an error in fetching course stats that occured when a course has an unusually large number of highly active rooms.