### PR TITLE
 Popup when control requested

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -379,6 +379,20 @@ class Workspace extends Component {
       });
     });
 
+    socket.on('CONTROL_REQUESTED', (message) => {
+      this.addToLog(message);
+      sendControlEvent(controlEvents.MSG_RECEIVED_REQUEST, {
+        tab: message.tab,
+      });
+    });
+
+    socket.on('REQUEST_CANCELLED', (message) => {
+      this.addToLog(message);
+      sendControlEvent(controlEvents.MSG_REQUEST_CANCELLED, {
+        tab: message.tab,
+      });
+    });
+
     socket.on('CREATED_TAB', (data) => {
       const { tabs: stateTabs } = this.state;
       this.addToLog(data.message);
@@ -994,6 +1008,7 @@ class Workspace extends Component {
       resetRoom,
       user,
       controlState,
+      sendControlEvent,
     } = this.props;
     const {
       tabs: currentTabs,

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -1008,7 +1008,6 @@ class Workspace extends Component {
       resetRoom,
       user,
       controlState,
-      sendControlEvent,
     } = this.props;
     const {
       tabs: currentTabs,

--- a/client/src/utils/controlMachine.js
+++ b/client/src/utils/controlMachine.js
@@ -597,7 +597,10 @@ export function withControlMachine(Component) {
     const { hide, show } = useAppModal();
 
     React.useEffect(() => {
-      if (state.matches(controlStates.RECEIVED_REQUEST))
+      if (
+        state.matches(controlStates.RECEIVED_REQUEST) &&
+        !state.history.matches(controlStates.RECEIVED_REQUEST)
+      )
         show(
           <div>
             <div>Control has been requested.</div>
@@ -617,7 +620,7 @@ export function withControlMachine(Component) {
             </div>
           </div>
         );
-      else if (state.matches(controlStates.REQUEST_CANCELLED)) hide();
+      else if (!state.matches(controlStates.RECEIVED_REQUEST)) hide();
     }, [state.value]);
 
     return (

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -277,6 +277,22 @@ module.exports = function() {
       if (callback) callback(null, {});
     });
 
+    socket.on('REQUEST_CONTROL', (data, callback) => {
+      socketMetricInc('requestcontrol');
+
+      controllers.messages.post(data);
+      socket.to(data.room).emit('CONTROL_REQUESTED', data);
+      if (callback) callback(null, {});
+    });
+
+    socket.on('CANCEL_REQUEST', (data, callback) => {
+      socketMetricInc('cancelrequest');
+
+      controllers.messages.post(data);
+      socket.to(data.room).emit('REQUEST_CANCELLED', data);
+      if (callback) callback(null, {});
+    });
+
     socket.on('SEND_EVENT', async (data, lastEventId, callback) => {
       socketMetricInc('eventsend');
       try {


### PR DESCRIPTION
This PR implements a popup box that appears to the person who is in control (of a room or a particular tab) when someone requests control. The person in control can then either release control or take one more minute. After that minute, control automatically releases.  If the person who requested control cancels that request, the person in control remains in control until they release control or idle for more than a minute.