### PR TITLE
Cleanup tab name in DropdownTabs & CurrentMembers

### DIFF
--- a/client/src/Components/CurrentMembers/CurrentMembers.js
+++ b/client/src/Components/CurrentMembers/CurrentMembers.js
@@ -103,7 +103,7 @@ function CurrentMembers({
       >
         {presentMembers.map((presMember) => {
           if (presMember) {
-            const shortName = `${shortenName(presMember.user.username)} ${
+            const shortName = `${shortenName(presMember.user.username)}: ${
               presMember.tabNum
             }`;
             return (

--- a/client/src/Containers/Workspace/DropdownTabs.js
+++ b/client/src/Containers/Workspace/DropdownTabs.js
@@ -43,7 +43,7 @@ const Tabs = ({
         onChange={(selectedOption) => onChangeTab(selectedOption.value)}
         value={
           tabs.length > 1
-            ? { ...currentSelection, label: `Tab: ${currentSelection.label}` }
+            ? { ...currentSelection, label: `${currentSelection.label}` }
             : { ...currentSelection, label: currentSelection.label }
         }
         isSearchable={false}


### PR DESCRIPTION
Remove "Tab:" from the tabs dropdown & add a colon to the tab number in the current members list.