### PR TITLE
Use controlMachine to determine room control per tab

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -996,6 +996,17 @@ class Workspace extends Component {
     socket.emit('SEND_EVENT', eventData, lastEventId, () => {});
   };
 
+  inControl = (tabId) => {
+    const { controlState } = this.props;
+    const { currentTabId } = controlState;
+
+    if (tabId === currentTabId)
+      return controlState.inControl || controlStates.NONE;
+    return controlState.controllers[tabId]
+      ? controlStates.OTHER
+      : controlStates.NONE;
+  };
+
   render() {
     const {
       populatedRoom,
@@ -1038,7 +1049,6 @@ class Workspace extends Component {
       connectionStatus,
     } = this.state;
     const { currentTabId } = controlState;
-    const inControl = controlState.inControl || controlStates.NONE;
 
     const currentMembers = this.configureCurrentMembersComponent();
     const tabs = (
@@ -1097,7 +1107,7 @@ class Workspace extends Component {
         currentTabId={currentTabId}
         updateRoomTab={connectUpdateRoomTab}
         tab={tab}
-        inControl={inControl}
+        inControl={this.inControl(tab._id)}
         toggleControl={this.toggleControl}
         updatedRoom={connectUpdatedRoom}
         addNtfToTabs={this.addNtfToTabs}

--- a/client/src/utils/controlMachine.js
+++ b/client/src/utils/controlMachine.js
@@ -181,7 +181,7 @@ const defaultControlMachineSpec = (initial, context) => {
       predictableActionArguments: true,
       id: 'control',
       initial,
-      context: { ...context, strategy: STRATEGY.DEFAULT },
+      context: { ...context, controllers: null, strategy: STRATEGY.DEFAULT },
       on: {
         [controlEvents.MSG_RELEASED_CONTROL]: {
           target: controlStates.NONE,
@@ -558,15 +558,29 @@ export function useControlMachine(context, spec) {
   const topLevelState = (stateValue) =>
     typeof stateValue === 'string' ? stateValue : Object.keys(stateValue)[0];
 
+  const getControlledBy = (tabId) => {
+    if (tabId === state.context.currentTabId || !state.context.controllers)
+      return state.context.controlledBy;
+    return state.context.controllers[tabId];
+  };
+
+  const getInControl = (tabId) => {
+    if (tabId === state.context.currentTabId || !state.context.controllers)
+      return topLevelState(state.value);
+    return state.context.controllers[tabId]
+      ? controlStates.OTHER
+      : controlStates.NONE;
+  };
+
   return [
     {
       ...state,
-      inControl: topLevelState(state.value),
       buttonConfig: state.context.buttonConfig,
       controlledBy: state.context.controlledBy,
       currentTabId: state.context.currentTabId,
-      controllers: state.context.controllers,
       lastMessage: state.context.lastMessage,
+      getControlledBy,
+      getInControl,
     },
     send,
   ];


### PR DESCRIPTION
This PR fixes a Desmos Activity cloned tab bug that acted as though multiple participants were in control of the same tab even though they were in control of different tabs. 