### PR TITLE
Fix chat issue related to Detailed Chat's activity markers & allow for ggb tab creation 

### DIFF
--- a/client/src/Containers/Create/NewTabForm.js
+++ b/client/src/Containers/Create/NewTabForm.js
@@ -173,7 +173,7 @@ class NewTabForm extends Component {
           <RadioBtn
             name={CLONE}
             checked={checkedNum === 0}
-            check={() => this.setState({ tabType: CLONE, checkedNum: 2 })}
+            check={() => this.setState({ tabType: CLONE, checkedNum: 0 })}
           >
             Clone Current Tab
           </RadioBtn>
@@ -190,7 +190,7 @@ class NewTabForm extends Component {
             name={TabTypes.GEOGEBRA}
             checked={checkedNum === 2}
             check={() =>
-              this.setState({ tabType: TabTypes.GEOGEBRA, checkedNum: 0 })
+              this.setState({ tabType: TabTypes.GEOGEBRA, checkedNum: 2 })
             }
           >
             GeoGebra

--- a/client/src/Containers/Workspace/DesmosActivity.js
+++ b/client/src/Containers/Workspace/DesmosActivity.js
@@ -140,10 +140,10 @@ const DesmosActivity = (props) => {
 
     socket.on('RECEIVE_EVENT', (data) => {
       // console.log('Socket: Received data: ', data);
-      addToLog(data);
       const { room } = props;
       receivingData = true;
       if (data.tab === tab._id) {
+        addToLog(data);
         const updatedTabs = room.tabs.map((t) => {
           if (t._id === data.tab) {
             t.currentState = data.currentState;

--- a/client/src/Containers/Workspace/DesmosGraph.js
+++ b/client/src/Containers/Workspace/DesmosGraph.js
@@ -446,10 +446,10 @@ class DesmosGraph extends Component {
       this.receivingData = false;
     });
     socket.on('RECEIVE_EVENT', (data) => {
-      addToLog(data);
       const { room } = this.props;
       this.receivingData = true;
       if (data.tab === tab._id) {
+        addToLog(data);
         const updatedTabs = room.tabs.map((t) => {
           if (t._id === data.tab) {
             t.currentState = data.currentState;


### PR DESCRIPTION
Activity markers:
- ensure that events are added to the log only once
- previously, Desmos Activity & potentiallyDesmos Graph tabs would duplicate events in the log based on the number of tabs of those type in a room. For example, in a room with 3 Desmos Activity tabs, events would be duplicated 3 times causing issues in the Chat