### PR TITLE
Handle user disconnect from VMT

### DIFF
--- a/server/sockets.js
+++ b/server/sockets.js
@@ -215,6 +215,31 @@ module.exports = function() {
           const messageText = `${socket.username} exited unexpectedly from VMT`;
           leaveRoom(roomId, null, null, messageText);
         }
+      } else {
+        if (socket.timer) clearTimeout(socket.timer);
+        socket.timer = setTimeout(() => {
+          const roomNames = Array.from(socket.rooms);
+
+          const objectIdPattern = /^[0-9a-fA-F]{24}$/; // Regular expression for ObjectId
+
+          const roomId = roomNames.find((roomName) =>
+            objectIdPattern.test(roomName)
+          );
+          if (roomId) {
+            socket.leave(roomId);
+            const messageText = `${socket.username} exited unexpectedly from VMT`;
+            leaveRoom(roomId, null, null, messageText);
+          }
+        }, 15000);
+        // set up a timer that will disconnect stuff as above after 30 seconds
+        // clear timer on reconnect event
+      }
+    });
+
+    socket.on('reconnect', () => {
+      if (socket.timer) {
+        clearTimeout(socket.timer);
+        socket.timer = null;
       }
     });
 

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -201,6 +201,21 @@ module.exports = function() {
         ', from rooms',
         socket.rooms
       );
+
+      if (reason === 'transport close') {
+        const roomNames = Array.from(socket.rooms);
+
+        const objectIdPattern = /^[0-9a-fA-F]{24}$/; // Regular expression for ObjectId
+
+        const roomId = roomNames.find((roomName) =>
+          objectIdPattern.test(roomName)
+        );
+        if (roomId) {
+          socket.leave(roomId);
+          const messageText = `${socket.username} exited unexpectedly from VMT`;
+          leaveRoom(roomId, null, null, messageText);
+        }
+      }
     });
 
     socket.on('SYNC_SOCKET', (_id, cb) => {


### PR DESCRIPTION
This PR recognizes when a user has either closed the browser tab containing VMT or navigates away. When this happens, the server acts as if the user left the room, sending a message to other users in the room ("XXX exited unexpectedly from VMT") and releasing control if that user had been in control.