### PR TITLE
Fix CurrentMembers tabNum display & minor code cleanup

### DIFF
--- a/client/src/Components/CurrentMembers/CurrentMembers.js
+++ b/client/src/Components/CurrentMembers/CurrentMembers.js
@@ -69,7 +69,7 @@ function CurrentMembers({
   const isActive = (id) => {
     // activeMember might be null, an array, or a string (id)
     if (!activeMember) return false;
-    else if (typeof activeMember === 'string') return activeMember === id;
+    if (typeof activeMember === 'string') return activeMember === id;
     return activeMember.includes(id);
   };
 
@@ -103,9 +103,12 @@ function CurrentMembers({
       >
         {presentMembers.map((presMember) => {
           if (presMember) {
-            const shortName = `${shortenName(presMember.user.username)}: ${
-              presMember.tabNum
-            }`;
+            const shortName =
+              presMember.tabNum > 0
+                ? `${shortenName(presMember.user.username)}: ${
+                    presMember.tabNum
+                  }`
+                : shortenName(presMember.user.username);
             return (
               <div
                 className={[

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -538,7 +538,7 @@ class Workspace extends Component {
 
   changeTab = (id) => {
     const { populatedRoom, user, sendControlEvent, controlState } = this.props;
-    const { activityOnOtherTabs, myColor, tabs } = this.state;
+    const { myColor, tabs } = this.state;
     const { currentTabId } = controlState;
     this.clearReference();
     const newTabNum = tabs.findIndex((tab) => tab._id === id) + 1;
@@ -617,6 +617,8 @@ class Workspace extends Component {
     }
   };
 
+  // End of Tab functions
+
   // If there's only one tab in a room, render CurrentMembers
   // If there's more than one tab, render DisplayTabsCM
   configureCurrentMembersComponent = () => {
@@ -665,10 +667,8 @@ class Workspace extends Component {
     );
   };
 
-  // End of Tab functions
-
   toggleControl = () => {
-    const { controlState, sendControlEvent, user } = this.props;
+    const { controlState, sendControlEvent } = this.props;
     const { myColor, tabs } = this.state;
     const { currentTabId } = controlState;
     if (!socket.connected) {


### PR DESCRIPTION
If there's only 1 tab, don't display the colon after the usernames. 