### PR TITLE
Community & Dashboard Load More Results fixes + keep Community NavItem underlined while in Community

### DIFF
--- a/client/src/Components/Navigation/NavItem/NavItem.js
+++ b/client/src/Components/Navigation/NavItem/NavItem.js
@@ -6,9 +6,14 @@ import classes from './navItem.css';
 import Checkbox from '../../Form/Checkbox/Checkbox';
 
 const NavItem = ({ name, link, ntf, sliderDetails }) => {
-  const style = window.location.href.includes(link)
-    ? classes.ActiveLink
-    : classes.Item;
+  // Community wasn't underlined because the link changed when clicking on templates or courses. the or below fixes that
+  // @TODO: fix this for all of the Info links
+  const style =
+    window.location.href.includes(link) ||
+    (typeof name === 'string' &&
+      window.location.href.includes(name.toLowerCase()))
+      ? classes.ActiveLink
+      : classes.Item;
 
   const dataName = typeof name === 'string' ? name : 'profile';
 

--- a/client/src/Layout/AdminDashboard/AdminDashboard.js
+++ b/client/src/Layout/AdminDashboard/AdminDashboard.js
@@ -155,6 +155,11 @@ class AdminDashboard extends Component {
                 ) : null}
               </Fragment>
             </InfoBox>
+            <div className={classes.LoadMore}>
+              <Button m={20} disabled={!moreAvailable} click={setSkip}>
+                load more results
+              </Button>
+            </div>
           </div>
         </div>
         <div
@@ -175,11 +180,6 @@ class AdminDashboard extends Component {
             manageUser={manageUser}
             ownUserId={ownUserId}
           />
-          <div className={classes.LoadMore}>
-            <Button m={20} disabled={!moreAvailable} click={setSkip}>
-              load more results
-            </Button>
-          </div>
         </div>
       </div>
     );

--- a/client/src/Layout/Community/Community.js
+++ b/client/src/Layout/Community/Community.js
@@ -96,8 +96,8 @@ class Community extends Component {
                 </RadioBtn>
               </div>
             </InfoBox>
-            {resource !== 'courses' ? (
-              <div className={classes.RoomTypeLoadMoreContainer}>
+            <div className={classes.RoomTypeLoadMoreContainer}>
+              {resource !== 'courses' ? (
                 <InfoBox
                   title="Room Type"
                   icon={<i className="fas fa-filter" />}
@@ -117,17 +117,17 @@ class Community extends Component {
                     />
                   </div>
                 </InfoBox>
-                <div className={classes.LoadMore}>
-                  <Button
-                    m={20}
-                    disabled={!moreAvailable || loading}
-                    click={setSkip}
-                  >
-                    load more results
-                  </Button>
-                </div>
+              ) : null}
+              <div className={classes.LoadMore}>
+                <Button
+                  m={20}
+                  disabled={!moreAvailable || loading}
+                  click={setSkip}
+                >
+                  load more results
+                </Button>
               </div>
-            ) : null}
+            </div>
           </div>
         </div>
         <div


### PR DESCRIPTION
In Community: Show "Load More Results" & keep Community nav link underlined when viewing templates or courses.
In Dashboard: Move "Load More Results" to top of page like in Community & Archive