### PR TITLE
Fix how URLs are constructed when clicking on resources, add templates to breadcrumbs

### DIFF
--- a/client/src/Layout/BoxList/BoxList.js
+++ b/client/src/Layout/BoxList/BoxList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Room } from 'Model';
+import { determineLinkPath } from 'utils';
 import ContentBox from '../../Components/UI/ContentBox/ContentBox';
 import DragContentBox from '../../Components/UI/ContentBox/DragContentBox';
 import classes from './boxList.css';
@@ -99,7 +100,9 @@ const boxList = (props) => {
                 title={item.name}
                 link={
                   linkPath !== null
-                    ? `${linkPath}${item._id}${linkSuffix}`
+                    ? `${determineLinkPath(item, resource)}${
+                        item._id
+                      }${linkSuffix}`
                     : null
                 }
                 key={item._id}

--- a/client/src/Layout/SelectableBoxList/SelectableBoxList.js
+++ b/client/src/Layout/SelectableBoxList/SelectableBoxList.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox, ToolTip } from 'Components';
 import SelectableContentBox from 'Components/UI/ContentBox/SelectableContentBox';
+import { determineLinkPath } from 'utils';
 import Expand from '../../Components/UI/ContentBox/expand';
 import classes from './SelectableBoxList.css';
 
@@ -230,7 +231,9 @@ const SelectableBoxList = (props) => {
                     // only allow default resources to be links
                     // disallow clicking on archived rooms
                     linkPath !== null && item.status === 'default'
-                      ? `${linkPath}${item._id}${linkSuffix}`
+                      ? `${determineLinkPath(item, resource)}${
+                          item._id
+                        }${linkSuffix}`
                       : null
                   }
                   key={item._id}

--- a/client/src/Routes/MyVmt.js
+++ b/client/src/Routes/MyVmt.js
@@ -39,6 +39,17 @@ const pages = [
     redirectPath: '/classcode',
   },
   {
+    path:
+      '/courses/:course_id/activities/:activity_id/rooms/:room_id/:resource',
+    component: Room,
+    redirectPath: '/classcode',
+  },
+  {
+    path: '/courses/:course_id/rooms/:room_id/:resource',
+    component: Room,
+    redirectPath: '/classcode',
+  },
+  {
     path: '/courses/:course_id/rooms/:room_id/:resource',
     component: Room,
     redirectPath: '/classcode',

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -20,3 +20,4 @@ export { default as addColors } from './addColors';
 export { default as hexToRGBA } from './hexToRGBA';
 export { default as dateAndTime } from './dateAndTime';
 export { GOOGLE_ICONS, getGoogleIcons } from './icons';
+export { determineLinkPath } from './urls';

--- a/client/src/utils/urls.js
+++ b/client/src/utils/urls.js
@@ -1,0 +1,25 @@
+/**
+ * According to Routes/MyVMT.js, we need the path to be in the form:
+ * 'myVMT/courses/:course_id/activities/:activity_id/rooms/:room_id/:resource'
+ *
+ * if the item has a course, we need to add it to the path
+ * if the item has an activity, we need to add it to the path after the course
+ * if the item has a room, we need to add it to the path after the activity
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const determineLinkPath = (item, resource) => {
+  let path = '/myVMT';
+
+  if (item.course) {
+    path += `/courses/${item.course}`;
+  }
+  if (item.activity) {
+    path += `/activities/${item.activity}`;
+  }
+  if (item.room) {
+    path += `/rooms/${item.room}/`;
+  }
+
+  path += `/${resource}/`;
+  return path;
+};


### PR DESCRIPTION
According to Routes/MyVMT.js, we need the path to be in the form:
'myVMT/courses/:course_id/activities/:activity_id/rooms/:room_id/:resource'
 
if the item has a course, we need to add it to the path
if the item has an activity, we need to add it to the path after the course
if the item has a room, we need to add it to the path after the activity