### PR TITLE
HOTFIX: bad room link

### DIFF
--- a/client/src/Routes/MyVmt.js
+++ b/client/src/Routes/MyVmt.js
@@ -45,6 +45,11 @@ const pages = [
     redirectPath: '/classcode',
   },
   {
+    path: '/activities/:activity_id/rooms/:room_id/:resource',
+    component: Room,
+    redirectPath: '/signup',
+  },
+  {
     path: '/courses/:course_id/rooms/:room_id/:resource',
     component: Room,
     redirectPath: '/classcode',


### PR DESCRIPTION
Fixed an error whereby an unrecognized route was being generated for rooms from standalone  templates.