### PR TITLE
Bump timeout to 30 min

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "private": true,
   "dependencies": {
     "@xstate/react": "^3.0.1",

--- a/client/src/Components/IdleDetector.js
+++ b/client/src/Components/IdleDetector.js
@@ -30,8 +30,7 @@ export default function IdleDetector({ children }) {
   // The activity detector hook listens for mouse clicks, keystrokes, or scolling events. If none of those happens
   // within 30 minutes, the user will be logged out.
 
-  // Use a relatively short timeout for demonstration; replace 30000 with 1800000 for 30 minutes
-  useActivityDetector(handleInactivity, handleActivity, 30000);
+  useActivityDetector(handleInactivity, handleActivity, 1800000);
 
   return <Fragment>{children}</Fragment>;
 }


### PR DESCRIPTION
* Increase timeout to the production value of 30 min
* keep all the logs in case testing is needed on vmt-staging. The logging will be removed before deploying to production.