### PR TITLE
Better updating of course preview

### DIFF
--- a/client/src/Components/SortUI/SortUI.js
+++ b/client/src/Components/SortUI/SortUI.js
@@ -10,7 +10,7 @@ const SortUI = ({
   sortFn,
   sortConfig,
   disableSort,
-  givenTimeFrames,
+  timeFrames: givenTimeFrames,
   disableSearch,
 }) => {
   const upArrow = <i className="fas fa-solid fa-arrow-up" />;
@@ -18,7 +18,6 @@ const SortUI = ({
   const timeFrameOptions = givenTimeFrames || [
     { label: 'All', value: timeFrames.ALL },
     { label: 'Last Day', value: timeFrames.LASTDAY },
-    { label: 'Last 2 Days', value: timeFrames.LAST2DAYS },
     { label: 'Last Week', value: timeFrames.LASTWEEK },
     { label: 'Last Two Weeks', value: timeFrames.LAST2WEEKS },
     { label: 'Last Month', value: timeFrames.LASTMONTH },
@@ -204,14 +203,14 @@ SortUI.propTypes = {
   }),
   disableSort: PropTypes.bool,
   disableSearch: PropTypes.bool,
-  givenTimeFrames: PropTypes.arrayOf(
+  timeFrames: PropTypes.arrayOf(
     PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
   ),
 };
 SortUI.defaultProps = {
   sortConfig: {},
   keys: [],
-  givenTimeFrames: null,
+  timeFrames: null,
   disableSort: false,
   disableSearch: false,
 };

--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -220,9 +220,6 @@ class Workspace extends Component {
         ),
         chat: log.filter((msg) => msg.messageType),
         tabs,
-        // The updatedAt field gets changed only by the DB. However, we update
-        // it in the Redux store so that other parts of the system can detect changes.
-        updatedAt: dateAndTime.toDBTimeString(Date.now()),
       });
     }
     window.removeEventListener('resize', this.resizeHandler);

--- a/client/src/utils/utilityHooks.js
+++ b/client/src/utils/utilityHooks.js
@@ -16,6 +16,9 @@ const timeFrameFcns = {
   lastWeek: (diff) => diff <= 7 * 24 * 60 * 60 * 1000,
   last2Weeks: (diff) => diff <= 2 * 7 * 24 * 60 * 60 * 1000,
   lastMonth: (diff) => diff <= 30 * 24 * 60 * 60 * 1000,
+  last3Months: (diff) => diff <= 3 * 30 * 24 * 60 * 60 * 1000,
+  last6Months: (diff) => diff <= 6 * 30 * 24 * 60 * 60 * 1000,
+  last9Months: (diff) => diff <= 9 * 30 * 24 * 60 * 60 * 1000,
   lastYear: (diff) => diff <= 356 * 24 * 60 * 60 * 1000,
   afterDay: (diff) => diff > 24 * 60 * 60 * 1000,
   afterWeek: (diff) => diff > 7 * 24 * 60 * 60 * 1000,
@@ -30,6 +33,9 @@ export const timeFrames = {
   LAST2DAYS: 'last2Days',
   LASTWEEK: 'lastWeek',
   LAST2WEEKS: 'last2Weeks',
+  LAST3MONTHS: 'last3Months',
+  LAST6MONTHS: 'last6Months',
+  LAST9MONTHS: 'last9Months',
   LASTMONTH: 'lastMonth',
   LASTYEAR: 'lastYear',
   AFTERDAY: 'afterDay',
@@ -562,4 +568,19 @@ export function useActivityDetector(
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);
+}
+
+/**
+ * A custom hook for executing a callback the first time that some data changes. Note that the callback should be stable
+ * or wrapped in useCallback.
+ */
+export function useExecuteOnFirstUpdate(data, callback) {
+  const hasExecutedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!hasExecutedRef.current && data) {
+      callback(data);
+      hasExecutedRef.current = true;
+    }
+  }, [data, callback]);
 }


### PR DESCRIPTION
The rooms in Course Preview will be sorted in reverse chronological order as per the updatedAt field from the DB in the following cases:
- the user leaves and reenters course preview (e.g., entering, making a change, then leaving a room)
- the user selects a different filtering timeframe from the dropdown
- the user refreshes the browser window (as has always been the case)
- the user logs out and back in (as has always been the case)

This PR also adds filtering timeframes of 3, 6, and 9 months.