### PR TITLE
Sortable monitors

### DIFF
--- a/client/src/Components/SortUI/SortUI.js
+++ b/client/src/Components/SortUI/SortUI.js
@@ -12,6 +12,8 @@ const SortUI = ({
   disableSort,
   timeFrames: givenTimeFrames,
   disableSearch,
+  disableFilter,
+  disableLabels,
 }) => {
   const upArrow = <i className="fas fa-solid fa-arrow-up" />;
   const downArrow = <i className="fas fa-solid fa-arrow-down" />;
@@ -111,7 +113,7 @@ const SortUI = ({
         {!disableSort && (
           <div className={classes.SortSelection}>
             <label htmlFor={`sortUI-${labelSuffix}`} className={classes.Label}>
-              Sort by:
+              {!disableLabels && 'Sort by:'}
               <Select
                 className={classes.Select}
                 inputId={`sortUI-${labelSuffix}`}
@@ -146,31 +148,33 @@ const SortUI = ({
             </span>
           </div>
         )}
-        <div className={classes.FilterSelection}>
-          <label
-            htmlFor={`filterUI-${labelSuffix}`}
-            className={classes.Label}
-            data-testid={`filterUI-${labelSuffix}`}
-          >
-            Updated:
-            <Select
-              placeholder="Timeframe"
-              className={classes.Select}
-              inputId={`filterUI-${labelSuffix}`}
-              onChange={(selectedOption) => {
-                sortFn({
-                  filter: {
-                    ...sortConfig.filter,
-                    timeframe: selectedOption.value,
-                  },
-                });
-              }}
-              value={optionForValue(sortConfig.filter.timeframe)}
-              options={timeFrameOptions}
-              isSearchable={false}
-            />
-          </label>
-        </div>
+        {!disableFilter && (
+          <div className={classes.FilterSelection}>
+            <label
+              htmlFor={`filterUI-${labelSuffix}`}
+              className={classes.Label}
+              data-testid={`filterUI-${labelSuffix}`}
+            >
+              {!disableLabels && 'Updated:'}
+              <Select
+                placeholder="Timeframe"
+                className={classes.Select}
+                inputId={`filterUI-${labelSuffix}`}
+                onChange={(selectedOption) => {
+                  sortFn({
+                    filter: {
+                      ...sortConfig.filter,
+                      timeframe: selectedOption.value,
+                    },
+                  });
+                }}
+                value={optionForValue(sortConfig.filter.timeframe)}
+                options={timeFrameOptions}
+                isSearchable={false}
+              />
+            </label>
+          </div>
+        )}
       </div>
       {!disableSearch && (
         <div className={classes.Search}>
@@ -203,6 +207,8 @@ SortUI.propTypes = {
   }),
   disableSort: PropTypes.bool,
   disableSearch: PropTypes.bool,
+  disableFilter: PropTypes.bool,
+  disableLabels: PropTypes.bool,
   timeFrames: PropTypes.arrayOf(
     PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
   ),
@@ -213,6 +219,8 @@ SortUI.defaultProps = {
   timeFrames: null,
   disableSort: false,
   disableSearch: false,
+  disableFilter: false,
+  disableLabels: false,
 };
 
 export default SortUI;

--- a/client/src/Containers/Monitoring/AllRoomsMonitor.js
+++ b/client/src/Containers/Monitoring/AllRoomsMonitor.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { timeFrames, API, dateAndTime, amIAFacilitator } from 'utils';
-import RecentMonitor from './RecentMonitor';
+import { API, dateAndTime, amIAFacilitator } from 'utils';
+import RecentMonitorAlt from './RecentMonitorAlt';
 
 /**
  * The AllRoomsMonitor provides views into all of the rooms associated with
@@ -10,22 +10,16 @@ import RecentMonitor from './RecentMonitor';
  * by updatedAt field).
  */
 
-function AllRoomsMonitor({ user, userResources }) {
+function AllRoomsMonitor({ user }) {
   const config = {
     key: 'updatedAt',
     direction: 'descending',
-    filter: { timeframe: timeFrames.LAST2DAYS, key: 'updatedAt' },
   };
 
-  const [roomsShown, setRoomsShown] = React.useState(0);
-
-  // Note: THe total might not be accurate if new rooms are created since logging in.
-  // However, a person might be the facilitator on 1000s of rooms, so I don't want to do a DB
-  // fetch for everything just to get an accourate count.
-
-  const totalRooms = userResources.filter((room) =>
-    amIAFacilitator(room, user._id)
-  ).length;
+  const sortKeys = [
+    { property: 'updatedAt', name: 'Sort by Last Updated' },
+    { property: 'name', name: 'Sort by Name' },
+  ];
 
   const fetchUserRooms = () => {
     const twoDaysAgo = dateAndTime.before(Date.now(), 2, 'days');
@@ -44,16 +38,15 @@ function AllRoomsMonitor({ user, userResources }) {
   return (
     <div>
       <p style={{ fontSize: '1.5em' }}>
-        Rooms with activity in the past 48 hours {'('}
-        {roomsShown} active of {totalRooms} total{')'}
+        Rooms with activity in the past 48 hours
       </p>
-      <p>(Use brower refresh to find newly active rooms)</p>
+      <p>(Navigate away and back to find newly active rooms)</p>
       <br />
-      <RecentMonitor
+      <RecentMonitorAlt
         config={config}
         context={`userRooms-${user._id}`}
         fetchRooms={fetchUserRooms}
-        setRoomsShown={setRoomsShown}
+        sortKeys={sortKeys}
       />
     </div>
   );

--- a/client/src/Containers/Monitoring/RecentMonitorAlt.js
+++ b/client/src/Containers/Monitoring/RecentMonitorAlt.js
@@ -8,13 +8,13 @@ import RoomsMonitor from './RoomsMonitor';
 import classes from './monitoringView.css';
 
 /**
- * The RecentMonitor provides views into a set of rooms, keeping them updated and detecting new activity and new rooms.
+ * The RecentMonitorAlt provides views into a set of rooms, keeping them updated and detecting new activity and new rooms.
  * context is a unique label used by the UIState
  * config provides the sorting and filtering configuration.
  * fetchRooms is a function that returns a set of rooms from the DB
  */
 
-function RecentMonitor({
+function RecentMonitorAlt({
   context,
   config,
   sortKeys, // array of {property, name}
@@ -111,15 +111,6 @@ function RecentMonitor({
         />
       ) : (
         <div>
-          {sortKeys && (
-            <SortUI
-              keys={sortKeys}
-              sortFn={resetSort}
-              sortConfig={sortConfig}
-              disableFilter
-            />
-          )}
-          <br />
           <RoomsMonitor
             context={context}
             populatedRooms={_pickBy(
@@ -127,6 +118,18 @@ function RecentMonitor({
               (_, id) => selections[id]
             )} // provide only the selected rooms
             isLoading={populatedRooms.isFetching ? roomIds : []}
+            customComponent={
+              sortKeys && (
+                <SortUI
+                  keys={sortKeys}
+                  sortFn={resetSort}
+                  sortConfig={sortConfig}
+                  disableFilter
+                  disableLabels
+                  disableSearch
+                />
+              )
+            }
           />
         </div>
       )}
@@ -134,7 +137,7 @@ function RecentMonitor({
   );
 }
 
-RecentMonitor.propTypes = {
+RecentMonitorAlt.propTypes = {
   context: PropTypes.string.isRequired,
   config: PropTypes.shape({}).isRequired,
   fetchRooms: PropTypes.func.isRequired,
@@ -144,11 +147,11 @@ RecentMonitor.propTypes = {
   selectionConfig: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-RecentMonitor.defaultValues = {
+RecentMonitorAlt.defaultValues = {
   setRoomsShown: null,
   fetchInterval: null,
   selectionConfig: null,
   sortKeys: null,
 };
 
-export default RecentMonitor;
+export default RecentMonitorAlt;

--- a/client/src/Containers/Monitoring/RoomsMonitor.js
+++ b/client/src/Containers/Monitoring/RoomsMonitor.js
@@ -13,7 +13,7 @@ import Chart from 'Containers/Stats/Chart';
 import statsReducer, { initialState } from 'Containers/Stats/statsReducer';
 import { dateAndTime, useUIState } from 'utils';
 import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
+import _isEqual from 'lodash/isEqual';
 import Thumbnails from './Thumbnails';
 import QuickChat from './QuickChat';
 import classes from './monitoringView.css';
@@ -46,6 +46,7 @@ function RoomsMonitor({
   context, // used for saving and restoring UI state
   onVisible, // provides array of ids of rooms that are visible on the screen
   isLoading, // array of ids that are currently loading
+  customComponent, // a component that gets inserted right next to the admin warning
 }) {
   const constants = {
     CHAT: 'Chat',
@@ -269,7 +270,16 @@ function RoomsMonitor({
             )}
           </Fragment>
         </div>
-        {_adminWarning()}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+        >
+          {customComponent}
+          {_adminWarning()}
+        </div>
         {Object.keys(populatedRooms).length === 0 ? (
           <div className={classes.NoSnapshot}>No rooms to display</div>
         ) : (
@@ -410,6 +420,7 @@ RoomsMonitor.propTypes = {
   context: PropTypes.string.isRequired,
   onVisible: PropTypes.func,
   isLoading: PropTypes.arrayOf(PropTypes.string),
+  customComponent: PropTypes.node,
 };
 
 RoomsMonitor.defaultProps = {
@@ -443,5 +454,5 @@ DropdownMenu.defaultProps = {
 const mapStateToProps = (state) => ({ user: state.user });
 
 export default connect(mapStateToProps)(
-  React.memo(RoomsMonitor, (prev, next) => isEqual(prev, next))
+  React.memo(RoomsMonitor, (prev, next) => _isEqual(prev, next))
 );


### PR DESCRIPTION
This PR implements sortable monitors. There are two alternatives presented for review:
1. In course monitor, the sorting looks similar to the one in MyVMT. It is above the toggles for the room and it allows for sorting by name or last updated, in either direction. It also allows filtering by room name.
2. The MyVMT monitor is simpler, with options to allow sorting by name or last updated, in either direction. The sort options are placed to the left of the warning for admins (if it's there).

These are two alternative designs for monitor sorting. Once decided, either (or another alternative) can be implemented in any or all monitors.

Still to implement: A refresh button rather than the message that's beneath the monitor heading.