### PR TITLE
Sortable Monitors

### DIFF
--- a/client/src/Containers/Monitoring/CourseMonitor.js
+++ b/client/src/Containers/Monitoring/CourseMonitor.js
@@ -59,7 +59,6 @@ function CourseMonitor({ course }) {
       <p style={{ fontSize: '1.5em' }}>
         Rooms with activity in the past 48 hours
       </p>
-      <p>(Navigate away and back to find newly active rooms)</p>
       <br />
       <RecentMonitor
         config={config}

--- a/client/src/Containers/Monitoring/RecentMonitor.js
+++ b/client/src/Containers/Monitoring/RecentMonitor.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import _pickBy from 'lodash/pickBy';
 import _keyBy from 'lodash/keyBy';
 import { usePopulatedRooms, useSortableData, useUIState } from 'utils';
-import { SimpleLoading, SelectionTable, ToggleGroup, SortUI } from 'Components';
+import {
+  SimpleLoading,
+  SelectionTable,
+  ToggleGroup,
+  SortUI,
+  Button,
+} from 'Components';
 import RoomsMonitor from './RoomsMonitor';
 import classes from './monitoringView.css';
 
@@ -22,7 +28,6 @@ function RecentMonitor({
   selectionConfig,
 }) {
   const roomsToSort = React.useRef([]);
-  const initialLoad = React.useRef(true);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const constants = {
@@ -65,17 +70,14 @@ function RecentMonitor({
     setSelections((prev) => ({ ...prev, ...newSelections }));
 
   const _fetchAndSetRooms = async () => {
-    if (initialLoad.current) setIsLoading(true);
+    setIsLoading(true);
     roomsToSort.current = await fetchRooms();
     const defaultSelections = roomsToSort.current.reduce(
       (acc, room) => ({ ...acc, [room._id]: true }),
       {}
     );
     setSelections((prev) => ({ ...defaultSelections, ...prev })); // show any new rooms
-    if (initialLoad.current) {
-      setIsLoading(false);
-      initialLoad.current = false;
-    }
+    setIsLoading(false);
   };
 
   if (populatedRooms.isError) return <div>There was an error.</div>;
@@ -83,15 +85,25 @@ function RecentMonitor({
 
   return (
     <div>
-      {selectionConfig && (
-        <div className={classes.TogglesContainer}>
+      <div
+        style={{
+          marginBottom: '20px',
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'row',
+        }}
+      >
+        <div style={{ marginRight: '20px' }}>
+          <Button click={async () => await _fetchAndSetRooms()}>Refresh</Button>
+        </div>
+        {selectionConfig && (
           <ToggleGroup
             buttons={[constants.VIEW, constants.SELECT]}
             onChange={setViewOrSelect}
           />
-        </div>
-      )}
-      {viewOrSelect === constants.SELECT ? (
+        )}
+      </div>
+      {selectionConfig && viewOrSelect === constants.SELECT ? (
         <SelectionTable
           data={roomsToSort.current}
           config={selectionConfig}

--- a/client/src/Containers/Monitoring/RecentMonitorAlt.js
+++ b/client/src/Containers/Monitoring/RecentMonitorAlt.js
@@ -19,8 +19,6 @@ function RecentMonitorAlt({
   config,
   sortKeys, // array of {property, name}
   fetchRooms,
-  setRoomsShown,
-  fetchInterval,
   selectionConfig,
 }) {
   const roomsToSort = React.useRef([]);
@@ -33,7 +31,7 @@ function RecentMonitorAlt({
   };
 
   const [uiState, setUIState] = useUIState(
-    `monitoring-container-${context}`,
+    `monitoring-container-alt-${context}`,
     {}
   );
   const [viewOrSelect, setViewOrSelect] = React.useState(constants.VIEW);
@@ -51,36 +49,13 @@ function RecentMonitorAlt({
   const { items: rooms, resetSort, sortConfig } = useSortableData(
     populatedRooms.isSuccess && populatedRooms.data
       ? Object.values(populatedRooms.data)
-      : roomsToSort.current,
+      : [],
     uiState.sortConfig || config
   );
 
   React.useEffect(() => {
-    const fetchAndSetRooms = async () => {
-      if (initialLoad.current) setIsLoading(true);
-      roomsToSort.current = await fetchRooms();
-      const defaultSelections = roomsToSort.current.reduce(
-        (acc, room) => ({ ...acc, [room._id]: true }),
-        {}
-      );
-      setSelections((prev) => ({ ...defaultSelections, ...prev })); // show any new rooms
-      if (initialLoad.current) {
-        setIsLoading(false);
-        initialLoad.current = false;
-      }
-    };
-
-    fetchAndSetRooms();
-
-    if (fetchInterval) {
-      const intervalId = setInterval(fetchAndSetRooms, fetchInterval);
-      return () => clearInterval(intervalId);
-    }
+    _fetchAndSetRooms();
   }, []);
-
-  React.useEffect(() => {
-    if (setRoomsShown) setRoomsShown(roomIds.length);
-  }, [roomIds]);
 
   React.useEffect(() => {
     setUIState({ selections, sortConfig });
@@ -88,6 +63,20 @@ function RecentMonitorAlt({
 
   const _updateSelections = (newSelections) =>
     setSelections((prev) => ({ ...prev, ...newSelections }));
+
+  const _fetchAndSetRooms = async () => {
+    if (initialLoad.current) setIsLoading(true);
+    roomsToSort.current = await fetchRooms();
+    const defaultSelections = roomsToSort.current.reduce(
+      (acc, room) => ({ ...acc, [room._id]: true }),
+      {}
+    );
+    setSelections((prev) => ({ ...defaultSelections, ...prev })); // show any new rooms
+    if (initialLoad.current) {
+      setIsLoading(false);
+      initialLoad.current = false;
+    }
+  };
 
   if (populatedRooms.isError) return <div>There was an error.</div>;
   if (populatedRooms.isLoading || isLoading) return <SimpleLoading />;
@@ -113,10 +102,11 @@ function RecentMonitorAlt({
         <div>
           <RoomsMonitor
             context={context}
+            // provide only the selected rooms
             populatedRooms={_pickBy(
               _keyBy(rooms, '_id'),
               (_, id) => selections[id]
-            )} // provide only the selected rooms
+            )}
             isLoading={populatedRooms.isFetching ? roomIds : []}
             customComponent={
               sortKeys && (
@@ -141,15 +131,15 @@ RecentMonitorAlt.propTypes = {
   context: PropTypes.string.isRequired,
   config: PropTypes.shape({}).isRequired,
   fetchRooms: PropTypes.func.isRequired,
-  sortKeys: PropTypes.arrayOf(PropTypes.shape({})),
+  sortKeys: PropTypes.arrayOf(
+    PropTypes.shape({ property: PropTypes.string, name: PropTypes.string })
+  ),
   setRoomsShown: PropTypes.func,
   fetchInterval: PropTypes.number,
   selectionConfig: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
 RecentMonitorAlt.defaultValues = {
-  setRoomsShown: null,
-  fetchInterval: null,
   selectionConfig: null,
   sortKeys: null,
 };


### PR DESCRIPTION
This PR adds a refresh button to two of the monitors:
* Course Monitor: Refresh button is next to the View/Select toggle
* MyVMT Monitor: Refresh button is part of the subheading for the monitor

This PR also fixes a bug that caused crashes when Chat was selected in a monitor.

These locations represent two alternative designs; the button could be placed in a number of other locations. We will ultimately place the refresh button consistently across monitors.