### PR TITLE
Editing tab URLs

### DIFF
--- a/client/src/Containers/Create/NewTabForm.js
+++ b/client/src/Containers/Create/NewTabForm.js
@@ -85,8 +85,8 @@ function NewTabForm({
             desmosLink,
             ...(tabType === TabTypes.PYRET
               ? {
-                  currentStateBase64: desmosLink,
-                  startingPointBase64: desmosLink,
+                  currentStateBase64: desmosLink, // used by rooms
+                  startingPointBase64: desmosLink, // used by rooms & templates
                 }
               : {}),
             appName,
@@ -174,6 +174,7 @@ function NewTabForm({
       </div>
       {requestURL(tabType) && (
         <TextInput
+          type="textarea"
           light
           value={displayLink}
           change={(event) => handleUpdateLink(tabType, event.target.value)}

--- a/client/src/Containers/Create/NewTabForm.js
+++ b/client/src/Containers/Create/NewTabForm.js
@@ -174,7 +174,6 @@ function NewTabForm({
       </div>
       {requestURL(tabType) && (
         <TextInput
-          type="textarea"
           light
           value={displayLink}
           change={(event) => handleUpdateLink(tabType, event.target.value)}

--- a/client/src/Containers/Workspace/ActivityWorkspace.js
+++ b/client/src/Containers/Workspace/ActivityWorkspace.js
@@ -67,6 +67,16 @@ class ActivityWorkspace extends Component {
     history.goBack();
   };
 
+  handleOnSave = (value) => {
+    const { activity, connectUpdateActivityTab } = this.props;
+    const { currentTabId } = this.state;
+    const currentTab = activity.tabs.find((t) => t._id === currentTabId);
+    if (!currentTab) return;
+
+    const updatedTab = TabTypes.getTemplateState(currentTab.tabType, value);
+    connectUpdateActivityTab(activity._id, currentTabId, updatedTab);
+  };
+
   render() {
     const {
       activity,
@@ -89,6 +99,7 @@ class ActivityWorkspace extends Component {
     let initialTab = null;
 
     if (activity && !currentTabId) {
+      console.log('setting initial tab');
       // activity has been loaded, but currentTab has not been updated
       // in state. Just use the first tab from the fetched activity
       // as the initial tab. If a user changes tabs, the currentTabId will
@@ -147,6 +158,8 @@ class ActivityWorkspace extends Component {
                 goBack={this.goBack}
                 copy={this.addToMyActivities}
                 tabs={activity.tabs}
+                currentTab={activity.tabs.find((t) => t._id == currentTabId)}
+                onSave={this.handleOnSave}
               />
             }
             bottomLeft={

--- a/client/src/Containers/Workspace/DesmosActivityEditor.js
+++ b/client/src/Containers/Workspace/DesmosActivityEditor.js
@@ -9,7 +9,24 @@ const DesmosActivityEditor = (props) => {
   const editorRef = useRef();
   const editorInst = useRef();
 
-  // trigger variable for any Desmos server response other than 200
+  useEffect(() => {
+    return () => {
+      if (editorInst.current) {
+        editorInst.current.destroy();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const initializeEditor = async () => {
+      if (editorInst.current) {
+        editorInst.current.destroy();
+      }
+      await initEditor();
+    };
+
+    initializeEditor();
+  }, [props.tab.desmosLink]);
 
   useEffect(() => {
     putState();
@@ -31,12 +48,7 @@ const DesmosActivityEditor = (props) => {
     if (config) {
       updateObject.currentStateBase64 = JSON.stringify(config);
     }
-    API.put('tabs', tab._id, updateObject)
-      .then(() => updateActivityTab(activity._id, tab._id, updateObject))
-      .catch((err) => {
-        // eslint-disable-next-line no-console
-        console.log(err);
-      });
+    updateActivityTab(activity._id, tab._id, updateObject);
   };
 
   const initEditor = async () => {
@@ -77,15 +89,6 @@ const DesmosActivityEditor = (props) => {
     // Go to screen last used
     return null;
   };
-
-  useEffect(() => {
-    initEditor();
-    return () => {
-      if (editorInst.current && !editorInst.current.isDestroyed()) {
-        editorInst.current.destroy();
-      }
-    };
-  }, []);
 
   return (
     <Fragment>

--- a/client/src/Containers/Workspace/PyretActivity.js
+++ b/client/src/Containers/Workspace/PyretActivity.js
@@ -6,12 +6,19 @@ import React, {
   Fragment,
 } from 'react';
 import PropTypes from 'prop-types';
-import ControlWarningModal from './ControlWarningModal';
 import { usePyret, socket, API } from 'utils';
+import ControlWarningModal from './ControlWarningModal';
 import classes from './graph.css';
 
 const CodePyretOrg = (props) => {
-  const { tab, inControl, user, setFirstTabLoaded, isFirstTabLoaded } = props;
+  const {
+    tab,
+    inControl,
+    user,
+    setFirstTabLoaded,
+    isFirstTabLoaded,
+    toggleControl,
+  } = props;
   const { currentStateBase64: initialState } = tab;
 
   const [showControlWarning, setShowControlWarning] = useState(false);
@@ -127,17 +134,10 @@ const CodePyretOrg = (props) => {
     return inControl === 'ME';
   }
 
-  function _checkForControl(event) {
-    if (!_hasControl()) {
-      event.preventDefault();
-      setShowControlWarning(true);
-    }
-  }
-
-  function _resetWarning() {
+  const _resetWarning = () => {
     setShowControlWarning(false);
     resetViolation();
-  }
+  };
 
   return (
     <Fragment>
@@ -145,7 +145,7 @@ const CodePyretOrg = (props) => {
         showControlWarning={showControlWarning}
         toggleControlWarning={_resetWarning}
         takeControl={() => {
-          props.toggleControl();
+          toggleControl();
           _resetWarning();
         }}
         inControl={inControl}
@@ -175,15 +175,26 @@ const CodePyretOrg = (props) => {
 };
 
 CodePyretOrg.propTypes = {
-  room: PropTypes.shape({}).isRequired,
-  tab: PropTypes.shape({}).isRequired,
-  user: PropTypes.shape({}).isRequired,
+  room: PropTypes.shape({
+    _id: PropTypes.string,
+    tabs: PropTypes.arrayOf(PropTypes.shape({})),
+  }).isRequired,
+  tab: PropTypes.shape({
+    _id: PropTypes.string,
+    currentStateBase64: PropTypes.string,
+  }).isRequired,
+  user: PropTypes.shape({
+    username: PropTypes.string,
+    inAdminMode: PropTypes.bool,
+  }).isRequired,
   updatedRoom: PropTypes.func.isRequired,
   toggleControl: PropTypes.func.isRequired,
   setFirstTabLoaded: PropTypes.func.isRequired,
+  isFirstTabLoaded: PropTypes.bool.isRequired,
   inControl: PropTypes.string.isRequired,
   addNtfToTabs: PropTypes.func.isRequired,
   addToLog: PropTypes.func.isRequired,
+  emitEvent: PropTypes.func.isRequired,
 };
 
 export default CodePyretOrg;

--- a/client/src/Containers/Workspace/PyretTemplateEditor.js
+++ b/client/src/Containers/Workspace/PyretTemplateEditor.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { usePyret, API } from 'utils';
 
@@ -10,7 +10,9 @@ const PyretTemplateEditor = (props) => {
     isFirstTabLoaded,
     updateActivityTab,
   } = props;
-  const { currentStateBase64: initialState } = tab;
+  const { currentStateBase64 } = tab;
+
+  const [initialState, setInitialState] = useState(currentStateBase64);
 
   const cpoIframe = useRef();
   const savedStateRef = useRef();
@@ -24,6 +26,10 @@ const PyretTemplateEditor = (props) => {
     onMessage,
     initialState
   );
+
+  useEffect(() => {
+    setInitialState(currentStateBase64);
+  }, [currentStateBase64]);
 
   useEffect(
     () => () => {
@@ -73,9 +79,14 @@ const PyretTemplateEditor = (props) => {
 };
 
 PyretTemplateEditor.propTypes = {
-  activity: PropTypes.shape({}).isRequired,
-  tab: PropTypes.shape({}).isRequired,
+  activity: PropTypes.shape({ _id: PropTypes.string }).isRequired,
+  tab: PropTypes.shape({
+    _id: PropTypes.string,
+    startingPointBase64: PropTypes.string,
+    currentStateBase64: PropTypes.string,
+  }).isRequired,
   setFirstTabLoaded: PropTypes.func.isRequired,
+  isFirstTabLoaded: PropTypes.bool.isRequired,
   updateActivityTab: PropTypes.func.isRequired,
 };
 

--- a/client/src/Containers/Workspace/Tools/ActivityTools.js
+++ b/client/src/Containers/Workspace/Tools/ActivityTools.js
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { getDesmosActivityUrl } from 'utils';
 import classes from './tools.css';
+import { TextInput, Button } from 'Components';
 
 const ActivityTools = (props) => {
-  const { owner, copy, goBack, tabs } = props;
+  const { owner, copy, goBack, tabs, currentTab, onSave } = props;
+  const [link, setLink] = useState(currentTab.desmosLink);
+
+  useEffect(() => {
+    setLink(currentTab.desmosLink);
+  }, [currentTab._id]);
+
   const tabdata = tabs.map((tab) => {
     if (tab.tabType === 'desmosActivity' && tab.desmosLink) {
       // Desmos Base URL: https://teacher.desmos.com/activitybuilder/custom/
@@ -110,6 +117,16 @@ const ActivityTools = (props) => {
                 copy this template
               </div>
             </div>
+          </div>
+        )}
+        {currentTab.desmosLink && (
+          <div>
+            <TextInput
+              light
+              value={link}
+              change={(event) => setLink(event.target.value)}
+            ></TextInput>
+            <Button click={() => onSave(link)}>Save</Button>
           </div>
         )}
         <div className={classes.Controls}>

--- a/client/src/Model/TabTypes.js
+++ b/client/src/Model/TabTypes.js
@@ -40,7 +40,9 @@ const activeTabTypes = [
   TAB_TYPES.DESMOS,
 ];
 
+// eslint-disable-next-line react/display-name
 const Blank = (type) => (props) => {
+  // eslint-disable-next-line react/prop-types
   const { setFirstTabLoaded, isFirstTabLoaded, setTabLoaded } = props;
   if (setFirstTabLoaded && !isFirstTabLoaded) setFirstTabLoaded();
   if (setTabLoaded) setTabLoaded();
@@ -167,6 +169,12 @@ function getTemplateState(tabType, value) {
     : {};
 }
 
+function hasInitializer(tabType) {
+  return (
+    tabTypeProperties[tabType].templateState !== defaultProperties.templateState
+  );
+}
+
 function Buttons({ onClick, disabled }) {
   return (
     <Fragment>
@@ -269,6 +277,7 @@ const TabTypes = {
   getDisplayName,
   hasReferences,
   getTemplateState,
+  hasInitializer,
 };
 
 export default TabTypes;

--- a/client/src/Model/TabTypes.js
+++ b/client/src/Model/TabTypes.js
@@ -58,6 +58,7 @@ const defaultProperties = (type) => ({
   editor: Blank(type), // The component used for editing templates
   icon: <img width={28} src="" alt="No Icon" />, // icon shown in resource lists
   references: false, // whether this tab type supports workspace referencing (arrows between mathspace and chat)
+  templateState: () => {},
 });
 
 if (
@@ -81,6 +82,11 @@ const tabTypeProperties = {
     component: CodePyretOrg,
     editor: PyretTemplateEditor,
     icon: <img width={28} src={pyretIcon} alt="Pyret Icon" />,
+    templateState: (value) => ({
+      desmosLink: value,
+      currentStateBase64: value,
+      startingPointBase64: value,
+    }),
   },
   [TAB_TYPES.WEBSKETCHPAD]: {
     ...defaultProperties('WebSketchpad Activity'),
@@ -112,6 +118,11 @@ const tabTypeProperties = {
     miniReplayer: DesActivityMiniReplayer,
     editor: DesmosActivityEditor,
     icon: <img width={25} src={dsmActIcon} alt="Desmos Activity Icon" />,
+    templateState: (value) => ({
+      desmosLink: value,
+      currentStateBase64: '{}',
+      startingPointBase64: '{}',
+    }),
   },
   multiple: { icon: <img width={25} src={bothIcon} alt="Multiple Types" /> },
 };
@@ -148,6 +159,12 @@ function hasReferences(tabType) {
   return tabTypeProperties[tabType]
     ? tabTypeProperties[tabType].references
     : false;
+}
+
+function getTemplateState(tabType, value) {
+  return tabTypeProperties[tabType]
+    ? tabTypeProperties[tabType].templateState(value)
+    : {};
 }
 
 function Buttons({ onClick, disabled }) {
@@ -251,6 +268,7 @@ const TabTypes = {
   activeTabTypes,
   getDisplayName,
   hasReferences,
+  getTemplateState,
 };
 
 export default TabTypes;


### PR DESCRIPTION
For Desmos Activity and Pyret rooms, allow the editor of a template to change the source URL/activity code of a tab. Useful if the person made a mistake originally.