### PR TITLE
Remove chat from redux store; replace with chat count

### DIFF
--- a/client/src/Containers/Workspace/Workspace.js
+++ b/client/src/Containers/Workspace/Workspace.js
@@ -211,7 +211,7 @@ class Workspace extends Component {
         currentMembers: currentMembers.filter(
           (mem) => mem && user && mem._id !== user._id
         ),
-        chat: log.filter((msg) => msg.messageType),
+        chatCount: log.filter((msg) => msg.messageType).length,
         tabs,
       });
     }

--- a/client/src/Layout/Dashboard/MainContent/RoomDetails.js
+++ b/client/src/Layout/Dashboard/MainContent/RoomDetails.js
@@ -34,7 +34,7 @@ class RoomDetails extends Component {
           {room.tabs ? room.tabs.length : 0}
         </InfoBox>
         <InfoBox title="Messages" icon={<i className="fas fa-comments" />}>
-          {room.chat ? room.chat.length : 0}
+          {room.chatCount || 0}
         </InfoBox>
       </div>
     );

--- a/client/src/store/reducers/roomsReducer.js
+++ b/client/src/store/reducers/roomsReducer.js
@@ -10,7 +10,20 @@ const initialState = {
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case actionTypes.GOT_ROOMS: {
-      const updatedRooms = merge({ ...state.byId }, action.byId);
+      const roomsWithChatCount = Object.keys(action.byId).reduce(
+        (acc, roomId) => {
+          const room = action.byId[roomId];
+          acc[roomId] = {
+            ...room,
+            chatCount: room.chat ? room.chat.length : 0,
+          };
+          delete acc[roomId].chat;
+          return acc;
+        },
+        {}
+      );
+
+      const updatedRooms = merge({ ...state.byId }, roomsWithChatCount);
       let updatedIds;
       if (action.isNewRoom) {
         updatedIds = union([...state.allIds], [...action.allIds]);


### PR DESCRIPTION
Removing the chat from rooms in the redux store should reduce the memory burden of 1000s of rooms.