### PR TITLE
Handle bandwidth issues with DB

### DIFF
--- a/client/src/store/reducers/roomsReducer.js
+++ b/client/src/store/reducers/roomsReducer.js
@@ -8,27 +8,15 @@ const initialState = {
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case actionTypes.GOT_ROOMS: {
-      // Note: We do not need the action.isNewRoom flag because we are handling duplicates via the Set in step 3
-      // Step 1: Process rooms to add chatCount and remove chat
-      const roomsWithChatCount = Object.keys(action.byId).reduce(
-        (acc, roomId) => {
-          const { chat, ...restOfRoom } = action.byId[roomId];
-          acc[roomId] = {
-            ...restOfRoom,
-            chatCount: chat ? chat.length : 0,
-          };
-          return acc;
-        },
-        {}
-      );
+      // Note: We do not need the action.isNewRoom flag because we are handling duplicates via the Set in step 2
 
-      // Step 2: Shallow merge state.byId and roomsWithChatCount
-      const updatedRooms = { ...state.byId, ...roomsWithChatCount };
+      // Step 1: Shallow merge state.byId and roomsWithChatCount
+      const updatedRooms = { ...state.byId, ...action.byId };
 
-      // Step 3: Combine and deduplicate IDs using a Set
+      // Step 2: Combine and deduplicate IDs using a Set
       const updatedIds = [...new Set([...state.allIds, ...action.allIds])];
 
-      // Step 4: Return the updated state
+      // Step 3: Return the updated state
       return {
         ...state,
         byId: updatedRooms,

--- a/server/app.js
+++ b/server/app.js
@@ -25,7 +25,11 @@ console.log('NODE_ENV=', process.env.NODE_ENV);
 
 const mongoURI = process.env.MONGO_URI;
 const isSecure = !mongoURI.includes('localhost');
-let mongoOptions = { useNewUrlParser: true, poolSize: 10 };
+let mongoOptions = {
+  useNewUrlParser: true,
+  poolSize: 10,
+  compressors: 'snappy',
+};
 if (isSecure) {
   mongoOptions = {
     ...mongoOptions,

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -32,33 +32,42 @@ module.exports = {
     });
   },
 
-  getById: (id) => {
-    return new Promise((resolve, reject) => {
-      db.User.findById(id)
-        .populate({
-          path: 'courses',
-          populate: { path: 'members.user', select: 'username' },
-        })
-        .populate({
-          path: 'rooms',
-          select: '-currentState',
-          populate: {
-            path: 'tabs members.user',
-            select: 'username tabType desmosLink name instructions',
-          },
-        })
-        .populate({
-          path: 'activities',
-          populate: { path: 'tabs', select: 'name tabType desmosLink' },
-        })
-        .populate({
-          path: 'notifications',
-          populate: { path: 'fromUser', select: '_id username' },
-        })
-        .then((user) => resolve(user))
-        .catch((err) => reject(err));
-    });
-  },
+  getById: (id) =>
+    db.User.findById(id)
+      .populate({
+        path: 'courses',
+        populate: { path: 'members.user', select: 'username' },
+      })
+      .populate({
+        path: 'rooms',
+        select: '-currentState',
+        populate: {
+          path: 'tabs members.user',
+          select: 'username tabType desmosLink name instructions',
+        },
+      })
+      .populate({
+        path: 'activities',
+        populate: { path: 'tabs', select: 'name tabType desmosLink' },
+      })
+      .populate({
+        path: 'notifications',
+        populate: { path: 'fromUser', select: '_id username' },
+      })
+      // remove chat field from each room; only need chatCount
+      .then((userMongoDoc) => {
+        if (!userMongoDoc || !userMongoDoc.rooms) return null;
+        const user = userMongoDoc.toObject();
+        user.rooms = user.rooms.map((room) => {
+          delete room.chat;
+          return room;
+        });
+        return user;
+      })
+      .catch((err) => {
+        console.log(err);
+        return null;
+      }),
   /**
    * @param  {String} username
    * @param {String} resourceName

--- a/server/models/Room.js
+++ b/server/models/Room.js
@@ -68,7 +68,6 @@ const Room = new mongoose.Schema(
     controlledBy: { type: ObjectId, ref: 'User', default: null },
     // wasNew: {type: Boolean},
     isTrashed: { type: Boolean, default: false },
-    snapshot: {},
     groupId: { type: String },
     status: {
       type: String,
@@ -83,6 +82,16 @@ const Room = new mongoose.Schema(
 Room.index({ isTrashed: 1, status: 1 });
 Room.index({ course: 1 });
 Room.index({ activity: 1 });
+
+// The chatCount field is used when users log in. Rather than storing the entire chat history in the redux store,
+// we only store the number of chat messages. When the user enters a room, we fetch the chat messages from the server.
+// (along with the entire populated room object).
+Room.virtual('chatCount').get(function() {
+  // console.log(this.name, this.chat);
+  return this.chat ? this.chat.length : 0;
+});
+Room.set('toJSON', { getters: true, virtuals: true });
+Room.set('toObject', { getters: true, virtuals: true });
 
 Room.pre('save', function(next) {
   this.dbUpdatedAt = Date.now();

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -70,29 +70,7 @@ const login = async (req, res) => {
 
     const verifiedToken = await jwt.verify(accessToken, secret);
     recordLogin(verifiedToken.vmtUserId);
-    const vmtUser = await User.findById(verifiedToken.vmtUserId)
-      .populate({
-        path: 'courses',
-        populate: { path: 'members.user', select: 'username' },
-      })
-      .populate({
-        path: 'rooms',
-        select: '-currentState',
-        populate: {
-          path: 'tabs members.user',
-          select: 'username tabType desmosLink name instructions',
-        },
-      })
-      .populate({
-        path: 'activities',
-        populate: { path: 'tabs' },
-      })
-      .populate({
-        path: 'notifications',
-        populate: { path: 'fromUser', select: '_id username' },
-      })
-      .lean()
-      .exec();
+    const vmtUser = await userController.getById(verifiedToken.vmtUserId);
 
     setSsoCookie(res, accessToken);
     setSsoRefreshCookie(res, refreshToken);
@@ -100,6 +78,7 @@ const login = async (req, res) => {
     const data = vmtUser;
     return res.json(data);
   } catch (err) {
+    console.log('err login', err);
     return errors.sendError.InternalError(null, res);
   }
 };
@@ -271,31 +250,8 @@ router.post('/resetPassword/:token', async (req, res) => {
       res.json({ message });
       return;
     }
-    // await jwt.verify(accessToken, process.env.MT_USER_JWT_SECRET);
 
-    const vmtUser = await User.findById(user.vmtUserId)
-      .populate({
-        path: 'courses',
-        populate: { path: 'members.user', select: 'username' },
-      })
-      .populate({
-        path: 'rooms',
-        select: '-currentState',
-        populate: {
-          path: 'tabs members.user',
-          select: 'username name tabType desmosLink',
-        },
-      })
-      .populate({
-        path: 'activities',
-        populate: { path: 'tabs', select: 'name tabType desmosLink' },
-      })
-      .populate({
-        path: 'notifications',
-        populate: { path: 'fromUser', select: '_id username' },
-      })
-      .lean()
-      .exec();
+    const vmtUser = await userController.getById(user.vmtUserId);
 
     setSsoCookie(res, accessToken);
     setSsoRefreshCookie(res, refreshToken);


### PR DESCRIPTION
After some investigation, it seems that the bandwidth spikes on the database server might be due to the logging in of users who have 1000s of rooms. This PR addresses this issue in two ways:
1. Implement compression of data between the database and application servers (enable built-in functionality of Mongoose)
2. Convert the chat field of all rooms into a 'chatCount' field. The chat field is no longer held on the client side unless someone is actually in a room.